### PR TITLE
feat: plecs-expert skill + pyplecs-mcp MCP server (closes #23)

### DIFF
--- a/.claude/commands/plecs.md
+++ b/.claude/commands/plecs.md
@@ -1,0 +1,8 @@
+---
+description: Look up PLECS docs (components, RPC, XML format, solver, codegen, C-Script). Routes to the plecs-expert skill.
+allowed-tools: Skill
+---
+
+Use the `plecs-expert` skill to answer the user's question, citing a `.claude/skills/plecs-expert/references/*` file or a `docs.plexim.com` URL. Apply caveman style per `style/caveman.md`.
+
+User question: $ARGUMENTS

--- a/.claude/hooks/pre_push_lint.py
+++ b/.claude/hooks/pre_push_lint.py
@@ -16,6 +16,7 @@ PYTEST_FILES = [
     "tests/test_entrypoint.py",
     "tests/test_install_full.py",
     "tests/test_abc_contract.py",
+    "tests/test_plecs_expert.py",
 ]
 
 

--- a/.claude/skills.md
+++ b/.claude/skills.md
@@ -84,11 +84,16 @@ tools\installers\windows_installer.bat --yes --plecs-path "C:\Program Files\Plex
 |---------|------|
 | Config | `config/default.yml` |
 | Core PLECS wrapper | `pyplecs/pyplecs.py` |
-| Data models | `pyplecs/core/models.py` |
+| Data models (pyplecs-local) | `pyplecs/core/models.py` |
+| Tool-agnostic ABC façade | `pyplecs/contracts.py` |
+| Vendored ABCs (pinned) | `pyplecs/_contracts/` |
 | Orchestration | `pyplecs/orchestration/__init__.py` |
 | Cache | `pyplecs/cache/__init__.py` |
 | REST API | `pyplecs/api/__init__.py` |
 | Web GUI | `pyplecs/webgui/webgui.py` |
+| Pre-push hook | `.claude/hooks/pre_push_lint.py` |
+| Re-sync vendored ABCs | `tools/SYNC_PYCIRCUITSIM_CORE.md` |
+| ABC compliance test | `tests/test_abc_contract.py` |
 
 ## Code Patterns
 
@@ -121,11 +126,21 @@ task_id = await orchestrator.submit_simulation(request, priority=TaskPriority.HI
 result = await orchestrator.wait_for_completion(task_id)
 ```
 
+### Tool-Agnostic Contracts (pyplecs.contracts)
+```python
+from pyplecs.contracts import (
+    SimulationServer, SimulationCacheBase, SimulationOrchestratorBase,
+    ConfigManagerBase, StructuredLoggerBase,
+    SimulationRequest, SimulationResult, SimulationStatus, TaskPriority,
+)
+# Resolves to PyPI pycircuitsim_core if installed and major-version-compatible,
+# otherwise to pyplecs._contracts. Diagnostic via `from pyplecs import contracts; contracts._source`.
+```
+
 ## Entry Points
 
 | Command | Module |
 |---------|--------|
 | `pyplecs-setup` | `pyplecs.cli.installer:main` |
-| `pyplecs-gui` | `pyplecs.webgui:main` |
+| `pyplecs-gui` | `pyplecs.webgui:run_app` |
 | `pyplecs-api` | `pyplecs.api:main` |
-| `pyplecs-mcp` | `pyplecs.mcp:main` |

--- a/.claude/skills/plecs-expert/LICENSE-NOTES.md
+++ b/.claude/skills/plecs-expert/LICENSE-NOTES.md
@@ -16,3 +16,4 @@
 | `references/solver.md` | https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
 | `references/codegen.md` | https://docs.plexim.com/plecs/latest/codegeneration/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
 | `references/cscript.md` | https://docs.plexim.com/plecs/latest/c-scripts/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/plecs-xml-grammar.md` | n/a (no public docs page) | n/a | hand-authored from `data/*.plecs` samples in Task 15 |

--- a/.claude/skills/plecs-expert/LICENSE-NOTES.md
+++ b/.claude/skills/plecs-expert/LICENSE-NOTES.md
@@ -17,3 +17,4 @@
 | `references/codegen.md` | https://docs.plexim.com/plecs/latest/codegeneration/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
 | `references/cscript.md` | https://docs.plexim.com/plecs/latest/c-scripts/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
 | `references/plecs-xml-grammar.md` | n/a (no public docs page) | n/a | hand-authored from `data/*.plecs` samples in Task 15 |
+| `references/url-index.md` | n/a (URL list only) | n/a | URL pointers (no Plexim prose mirrored) |

--- a/.claude/skills/plecs-expert/LICENSE-NOTES.md
+++ b/.claude/skills/plecs-expert/LICENSE-NOTES.md
@@ -4,3 +4,15 @@
 
 | File | Source URL | Verbatim sections | Rewritten sections |
 |------|-----------|-------------------|---------------------|
+| `references/components/electrical-passive.md` | https://docs.plexim.com/plecs/latest/components-by-category/resistor/ + inductor + capacitor + transformer | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/electrical-sources.md` | https://docs.plexim.com/plecs/latest/components-by-category/acvoltagesource/ + dcvoltagesource + controlledvoltagesource + controlledcurrentsource | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/electrical-switches.md` | https://docs.plexim.com/plecs/latest/components-by-category/mosfet/ + igbt + diode + switch | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/electrical-meters.md` | https://docs.plexim.com/plecs/latest/components-by-category/voltmeter/ + ammeter + scope | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/magnetic.md` | https://docs.plexim.com/plecs/latest/components-by-category/magneticpermeance/ + constantmmf + fluxratemeter | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/thermal.md` | https://docs.plexim.com/plecs/latest/components-by-category/heatsink/ + thermalcapacitor + ambienttemperature | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/control.md` | https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/ + transferfcn + statemachines | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/components/system.md` | https://docs.plexim.com/plecs/latest/components-by-category/subsystem/ + conf_subsystem + masking-subsystems | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/rpc-api.md` | https://docs.plexim.com/plecs/latest/scripting/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/solver.md` | https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/codegen.md` | https://docs.plexim.com/plecs/latest/codegeneration/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |
+| `references/cscript.md` | https://docs.plexim.com/plecs/latest/c-scripts/ | tables (verbatim) | prose (caveman, hand-authored — Task 6) |

--- a/.claude/skills/plecs-expert/LICENSE-NOTES.md
+++ b/.claude/skills/plecs-expert/LICENSE-NOTES.md
@@ -1,0 +1,6 @@
+# License Notes
+
+`docs.plexim.com` content is Plexim's proprietary documentation. This skill mirrors only **factual tables** verbatim (parameter names, defaults, units, RPC signatures, XML element grammar — facts not copyrightable) and rewrites all **prose** in our own caveman-style words.
+
+| File | Source URL | Verbatim sections | Rewritten sections |
+|------|-----------|-------------------|---------------------|

--- a/.claude/skills/plecs-expert/SKILL.md
+++ b/.claude/skills/plecs-expert/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: plecs-expert
+description: PLECS authoring help, .plecs schematic format, XML-RPC API, and SPICE-mapping reference. Use when answering "how do I X in PLECS", working on the netlist converter, or extending the PlecsServer XML-RPC wrapper.
+allowed-tools: Read, Grep, Glob, WebFetch, Bash
+---
+
+# PLECS Expert
+
+Lookup-first PLECS reference grounded in docs.plexim.com. Two layers:
+
+- **Layer A — offline docs**: `references/`. Verbatim factual tables + caveman prose.
+- **Layer B — pyplecs code**: `pyplecs.plecs_components`, `pyplecs.pyplecs.PlecsServer`. Live introspection.
+
+## Routing
+
+| Topic | File |
+|-------|------|
+| Electrical passives (R, L, C, transformer) | `references/components/electrical-passive.md` |
+| Sources (V, I, signal) | `references/components/electrical-sources.md` |
+| Switches (MOSFET, IGBT, diode) | `references/components/electrical-switches.md` |
+| Meters & scopes | `references/components/electrical-meters.md` |
+| Magnetic blocks | `references/components/magnetic.md` |
+| Thermal blocks | `references/components/thermal.md` |
+| Control library | `references/components/control.md` |
+| Subsystems & masks | `references/components/system.md` |
+| XML-RPC API | `references/rpc-api.md` |
+| `.plecs` XML grammar | `references/plecs-xml-grammar.md` |
+| Solver | `references/solver.md` |
+| Codegen (PLECS Coder) | `references/codegen.md` |
+| C-Script block | `references/cscript.md` |
+| Long-tail topics | `references/url-index.md` (then WebFetch the listed URL) |
+
+## Composition rule
+
+For component or RPC questions, check Layer B first. If a `*PlecsMdl` class exists in `pyplecs.plecs_components`, cite the wrapper. If a method exists on `PlecsServer`, cite it. Else cite Layer A. Else WebFetch from `references/url-index.md`.
+
+## Citation rule
+
+Every answer cites a `references/*` path or a `docs.plexim.com` URL. No ungrounded claims.
+
+## Style
+
+Generated prose follows `style/caveman.md`: fragments OK, drop articles/hedging/filler, pattern `[thing] [action] [reason]. [next step].`.
+
+## Boundary
+
+This skill does not cover: PLECS RT Box (separate future skill), license/purchasing, third-party libraries.

--- a/.claude/skills/plecs-expert/manifest.json
+++ b/.claude/skills/plecs-expert/manifest.json
@@ -3,112 +3,215 @@
   "files": {
     "references/components/electrical-passive.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Resistor.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Inductor.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Capacitor.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Transformer.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/resistor/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/inductor/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/capacitor/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/transformer/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "resistor-parameters": "ca3b5fcfbe3318b65ef6aec3d9a6fc6370fec21734192b1a87d591d285f7144c",
+        "resistor-probes": "6aad1a42f08d871db6c0537c085b1860c6aad4f3d71b0c66c971bb6716a454ea",
+        "inductor-parameters": "4edd45f6bb59c2eaaf6786ee05eec9e99defdd2b147937402c385c5ac5f523e9",
+        "inductor-probes": "ebba6dda24746e39dec493c352d1d2a7f9068fd18e1f1821c15e7716c2ea0667",
+        "capacitor-parameters": "5312cc75e41a7cee0082b57a0623d03a6cc8b6265ef35ffd0a147730fb5aa103",
+        "capacitor-probes": "e37eb191b37a43a7a21074191036e7842990c3b77ac0e92fcb457480d879fecf",
+        "transformer-parameters": "c9f2a5c07f1feb21abc17391f3e4509d007088bdeb00d89c3c1e39936dcadd7e"
+      },
       "prose_section_hashes": {}
     },
     "references/components/electrical-sources.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceAC.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceDC.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceControlled.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/CurrentSourceControlled.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/acvoltagesource/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/dcvoltagesource/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/controlledvoltagesource/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/controlledcurrentsource/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "acvoltagesource-parameters": "5ee9afeb17f4f81752ceab2a645da8c93bfd38731906321f6072558a9e05a45f",
+        "acvoltagesource-probes": "df0f128d465f2e9ca93df3a97e0f156855cc6dcbe0040cdebb31825162cda89e",
+        "dcvoltagesource-parameters": "e4ec89194d143d9a644546dfe9e590e8a8587766e5acdcf0f4d5d9bfa60288f2",
+        "dcvoltagesource-probes": "df0f128d465f2e9ca93df3a97e0f156855cc6dcbe0040cdebb31825162cda89e",
+        "controlledvoltagesource-parameters": "c90f24b2885368ab4206895577635f9a71fa9750f3e8e8db1e2372f13c2e073a",
+        "controlledvoltagesource-probes": "df0f128d465f2e9ca93df3a97e0f156855cc6dcbe0040cdebb31825162cda89e",
+        "controlledcurrentsource-parameters": "c90f24b2885368ab4206895577635f9a71fa9750f3e8e8db1e2372f13c2e073a",
+        "controlledcurrentsource-probes": "96fb4fe512eab8f74e20770839a82303156891e4d64e060020902753ac058dd1"
+      },
       "prose_section_hashes": {}
     },
     "references/components/electrical-switches.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Mosfet.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Igbt.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Diode.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/SwitchIdeal.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/mosfet/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/igbt/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/diode/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/switch/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "mosfet-parameters": "0676c5f41ea8c4e17c6e9032d69182538176d86078fb73a8aad9415a65fe9cf4",
+        "mosfet-probes": "721238e3e65d53ddc5cebb93d7b835f099beb21ec6949ed95e36b767d06813f2",
+        "igbt-parameters": "019d758501490d7a90e10ff68638586d0408187f127e4d6ab039eefda27f11d8",
+        "igbt-probes": "642f9ffb61bfcb50f8e2ad312de1adfa3715670d9cc448ca6f4af4bea8459a9c",
+        "diode-parameters": "1075309f05d31e43eb90040d608deee675a19cf21e4e4db10e2030a8b0440737",
+        "diode-probes": "828995d2591d6cc131472376549de2810ea66b16a52bf624ebb544153329818e",
+        "switch-parameters": "691dd2a93b8c9ad6796a83711568a129c56dada7301df8854605e49d3c4e15e7",
+        "switch-probes": "03ada57b82312d9dba019f208f4725ea68ce69c2fb3458aacedbd389a4e047dc"
+      },
       "prose_section_hashes": {}
     },
     "references/components/electrical-meters.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Voltmeter.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Ammeter.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/System/Scope.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/voltmeter/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/ammeter/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/scope/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "voltmeter-probes": "56a09dd908e778de0c9a7997e82e44421c6ab3872f530f5369ae7f40a58cfedc",
+        "ammeter-probes": "32acdaf9b547d4f982407c690568e0bdefc6133d25f6a8efc534ee4024374cbb",
+        "scope-scope-setup": "379bdcb703964f6ee521f7aed2c5a00a7ef32e991709a19f654d8ac8a123bf27",
+        "scope-time-axis-parameters": "e87e888bb04248c8e9e60224ee7bf61072f241d13c6d37f429e934fa63f9965f",
+        "scope-individual-plot-parameters": "e456514a06569be8a8550f35589a674d74dd8f9ba36ea83b68d8c4a4aa016276"
+      },
       "prose_section_hashes": {}
     },
     "references/components/magnetic.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/Permeance.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/MmfSource.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/FluxMeter.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/magneticpermeance/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/constantmmf/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/fluxratemeter/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "magneticpermeance-parameters": "e5812f51e3f663e35eb7afed390dbbba09e362188e5151621ea85d9962e8fb32",
+        "magneticpermeance-probes": "768f6dcfd44f654c9d3b8627003a0a7d755b774b3b7de02ac94c61e5f59370e8",
+        "constantmmf-parameters": "19007c88b6c702c1854c187a81c6958d8a842901122f24558b291b665548b571",
+        "constantmmf-probes": "469819f171544d20121a745b7a39eb5d2928d9609021985b286b264c9a7a508b",
+        "fluxratemeter-probes": "d2e9889a4f7a6fad724bb2a8f8b0aba9f7b6ba08bba06d4d694db90fb313ab1f"
+      },
       "prose_section_hashes": {}
     },
     "references/components/thermal.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/HeatSink.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/ThermalCapacitor.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/AmbientTemperature.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/heatsink/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/thermalcapacitor/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/ambienttemperature/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "heatsink-parameters": "c8ecacd541fd933602ab42bcf45df9dd3aff927ac15eb0ad693d6be4f4779278",
+        "heatsink-probes": "a6d4c311c75124882f4477390f5e481eb521506a8383a3ddc40b8eb234bc523c",
+        "thermalcapacitor-parameters": "2d14827f3fe4ae5122929f4f75a27e00b5bec284110d9d50ae3b9951dcea7376",
+        "thermalcapacitor-probes": "929617104520894e21b3c6a18949d3d3ce939585a319f92e8e0a9cccfcfbf4e5",
+        "ambienttemperature-parameters": "bfe734ec46ee359c958402ff686638f31353267a51c1841b2f94714c30ce5287"
+      },
       "prose_section_hashes": {}
     },
     "references/components/control.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Control/PIController.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Control/TransferFunction.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/Control/StateMachine.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/transferfcn/",
+        "https://docs.plexim.com/plecs/latest/statemachines/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "continuouspidcontroller-anti-windup-methods": "c951626e4dbb5645fae04f068916d6b17c544944f1063913626e262614ededcb",
+        "continuouspidcontroller-anti-windup-methods-2": "af699ebb9c56f68e92ecdc2121e0e3e39424b7055d2dbff1b640cdefc6fb1b08",
+        "continuouspidcontroller-basic": "80daee0e15baea536d0aab99a383e1b0a513c56e299d74a37ef28ea8528c0613",
+        "continuouspidcontroller-anti-windup": "2d64e9a4d66d696a77c86a1f54404b15d3b9774ea5a36ea9d6d0ea720a0e34cb",
+        "continuouspidcontroller-probes": "e19f850e68763403ffc978ce0a48ddee9cd3f764d83910ab9b3c815e194ece44",
+        "transferfcn-parameters": "9b5ac84a66d84e6d891a77978d05984fc170c8f7b5652dc7fba099a48b4d6b95",
+        "transferfcn-probes": "eda9d671707ed183da78d0d1b30e34f1e31ec7df5febb405a71d1d3df27bfec4",
+        "statemachines-table-0": "1a19dae24d6c44cb6113b5907dcaee9544c8fc548227d9236d1db9d9e02b9553",
+        "statemachines-table-1": "5b587bb42c82ef3514772e55f1ba7c2b8c750bf6435521ad576cdf60e1cd5c22"
+      },
       "prose_section_hashes": {}
     },
     "references/components/system.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/System/Subsystem.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/System/ConfigurableSubsystem.html",
-        "https://docs.plexim.com/plecs/latest/UserManual/System/Mask.html"
+        "https://docs.plexim.com/plecs/latest/components-by-category/subsystem/",
+        "https://docs.plexim.com/plecs/latest/components-by-category/conf_subsystem/",
+        "https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "subsystem-execution-settings": "581824359361cb103fc87db60c85b4ce668a5f7468a07389be03d1c2b5570c0c",
+        "conf_subsystem-parameters": "05d3a39060c05f55be166f644d6350b4f40e072504e67c4e4774fde51994bdc0",
+        "masking-subsystems-table-0": "883ffe9e6fed7d6b91bfb222d2a6196288dad67014c0ad19f25a9035a28bdd97",
+        "masking-subsystems-table-1": "6d93887918327b1a6ef2807ae7bc0a41b348f36b192d39852abafcab18f37bf6",
+        "masking-subsystems-table-2": "9b5aea2012004a72a731a167e9a6024bb4a2dee75580945261c2854639dd747c",
+        "masking-subsystems-table-3": "73b6046fa9f4789c04451c6565c455990109f4f0191cce4b91b6b0554210a42b",
+        "masking-subsystems-table-4": "7f8ff97f34d38a1fbb8c63f41ee7758b2523e78a817f6c50a61646646673d533",
+        "masking-subsystems-table-5": "d173d9fd0a044481c775da3aa0504e90f785569cd185e07eaf2e77197cfec731",
+        "masking-subsystems-table-6": "5c7dbe21d7042eb17034459a062f5f305f7051a7de9553e1fcd66f8585587faf",
+        "masking-subsystems-mask-icon-properties": "abd7a7f5e2a5b7a5c13baa466bb4f26e0b50a1bdd6c4af6b4bf6e23b5a0d1d80",
+        "masking-subsystems-mask-help": "1f59ddd316cba68a55b9402a05459b1d43f9344627a10c4f347442a3a831338f",
+        "masking-subsystems-types-and-variables": "e86e2cdca5122d770c92a40bafb6d29f4d24f8ea4e2a87f49f3c3720c90b29fd",
+        "masking-subsystems-control-structures": "2a4d544e49636aae92216b684f76ff45fb54e09deae4c5294e98dd46d6442b3b"
+      },
       "prose_section_hashes": {}
     },
     "references/rpc-api.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/XmlRpcInterface.html"
+        "https://docs.plexim.com/plecs/latest/scripting/"
       ],
-      "table_section_hashes": {},
-      "prose_section_hashes": {}
-    },
-    "references/plecs-xml-grammar.md": {
-      "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/PlecsFileFormat.html"
-      ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "scripting-table-0": "2d74b2835bbb6c21a22e9be8745edace51751d303548ce508861714490e2d9d9",
+        "scripting-table-1": "63ca83e9f357b3788e6f6bd609ed493fe809c794f804ba3b1686bd014d47aea8",
+        "scripting-table-2": "660a0dbb7b21c0d148a500d915486771ecd6644f1b708d8902b3bea80d1a3c5d",
+        "scripting-table-3": "4c0464e9d6130fb67ea3bddf8c191eae0d0db287451fab646bd62e256b36f287",
+        "scripting-scripted-simulation-and-analysis-options": "9ba39044078ac5b4b0a4af2ab71335e43cdc0a8235fa898fd39bf04995cfcfb4",
+        "scripting-scripted-simulation-and-analysis-options-2": "4844c78272c815bb4e0e36f1ff8954e5e44e537b119cbbfceada93a24188cc19"
+      },
       "prose_section_hashes": {}
     },
     "references/solver.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/Simulation/SolverSettings.html"
+        "https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "simulation-parameters-simulation-time": "e89a8dc082ab39b3013c4e468e8fa5884f9d5a43f8dc0169b6ca57b9bad56dd2",
+        "simulation-parameters-solver": "a964e3831d93845fa090952de89745e1df626825ae621d3829686184e0a2f208",
+        "simulation-parameters-solver-2": "7904a11caaf3b932de715e42ad1f3106ea4f13d8dcf02c5d17b178a2cc8fe73b",
+        "simulation-parameters-variable-step-solver-options": "5be53d4bdd83845edd0132b2f2a7bee978e7eb7351f1f21fd8c47bc146e74047",
+        "simulation-parameters-fixed-step-solver-options": "3392796b768d28f85fa019379f60f8241d00d47f09fe9680a6ccfe4289d7c773",
+        "simulation-parameters-circuit-model-options": "ca7576607686a81900fe4513885278334f8974642a8273f6c976181198e97be5",
+        "simulation-parameters-circuit-model-options-2": "c156f570a4646d11110343be5d54c711c9427952ea25c7de827a9873ced3a8a2",
+        "simulation-parameters-sample-times": "afa9856b74bfcc8c47ff1d62454237ccba3f300a90f6527dddf6c111b449c992",
+        "simulation-parameters-state-space-calculation": "cc8bf0b36fa706552ea502f8309112903838864d4fc4e54ea7b220accb85954f",
+        "simulation-parameters-data-types": "0b1d285fafb55e023c748de068e93f7f900178fa4b04e790c82b8ac84dfe43f4",
+        "simulation-parameters-assertions": "57749cfacb10a5243daae35a3ff2b954f2585fdd55c77c3f11fcef75761dac90",
+        "simulation-parameters-algebraic-loops": "26bf3701ef640764d3a4b46b97a420d8055b0de8111f6797e5ab7f3aa4515a04",
+        "simulation-parameters-diagnostics": "eca1c6068ffc13abc95d7d0c6d5bf3ecf57df3cad46a5d0cdfa2dddb3d59781f",
+        "simulation-parameters-system-state": "64849ef322c3452a27b79a9d7e670ad428805b8d4520fdb90cf34f8e6f5ed285",
+        "simulation-parameters-id1": "0ee18fc9be989eaa8f067f963729ab5bae932c96020c868df14cd9aa0eea5a50",
+        "simulation-parameters-discrete-state-space-options": "538a977cb0d48de4258c1ebfecf837bfe0e1349cc90235193776b454ee7af672",
+        "simulation-parameters-id2": "7c3de7e257578cbe5b9bea0f49a4bb306384f335b7d486bd5c74d2c9234d3fb2",
+        "simulation-parameters-id3": "8f78046d80166b57189ca22a65fba36095d7d16ebc7bf97d115f081300190839",
+        "simulation-parameters-id4": "26bf3701ef640764d3a4b46b97a420d8055b0de8111f6797e5ab7f3aa4515a04",
+        "simulation-parameters-id5": "cc8bf0b36fa706552ea502f8309112903838864d4fc4e54ea7b220accb85954f",
+        "simulation-parameters-simulink-coder": "edd348bdff8e0c49bfe128c4bcadb53f76d906481ed6ef2bb83b03930b232b68"
+      },
       "prose_section_hashes": {}
     },
     "references/codegen.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/CodeGeneration/Overview.html"
+        "https://docs.plexim.com/plecs/latest/codegeneration/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "codegeneration-table-0": "38b689582023381d1d61780f47df889c95c11f002a5f0ece36836bf05548260a",
+        "codegeneration-table-1": "651b8b021990e1a1c104a122d6285a2ec29b88a026a72d355ca0b98dbcaa1d67",
+        "codegeneration-switching-algorithm": "ec5f2e46664a616d6623be4e524eef4a61c99f0339623d89511e65c9b09264df",
+        "codegeneration-codegenswitchtypes": "df092bc72bd0e5dba7d603b567b0e97b3948af83a92848a3b0f84ce00d9cd0b2",
+        "codegeneration-code-generation-with-plecs-standalone": "2feee155fe7c0426d7699344d8bc865e8fdeef5963156e334b80118597ad85ef",
+        "codegeneration-general": "541d9636937cb67f47848a53eae15f560de33d1b93273c16e3ba10b58cccee78",
+        "codegeneration-parameter-inlining": "17266be55e1b23e27b1c2d31986552d67b8eba5fea8224917f87d66ae3ab3b59",
+        "codegeneration-target": "e1a6190475c16821a3479ae6d49e7f5d1b23180b314c85840b4cf3a99fdd4873",
+        "codegeneration-scheduling": "eb0bac52b5920e276fc7a1c51b1f72a77cb12f79f3a407f10d1b48f263513bbe",
+        "codegeneration-simulink-coder-options": "c1ea9769522879e3c9987ae6e56603de19526dd781395b252b45cd45e25b8fd6"
+      },
       "prose_section_hashes": {}
     },
     "references/cscript.md": {
       "source_urls": [
-        "https://docs.plexim.com/plecs/latest/UserManual/CScript.html"
+        "https://docs.plexim.com/plecs/latest/c-scripts/"
       ],
-      "table_section_hashes": {},
+      "table_section_hashes": {
+        "c-scripts-table-0": "e9edf84d99552bcea3fd44b3a7c3232a55925cd0f216d6e4b31bd667231e646c"
+      },
       "prose_section_hashes": {}
     }
   }

--- a/.claude/skills/plecs-expert/manifest.json
+++ b/.claude/skills/plecs-expert/manifest.json
@@ -1,0 +1,115 @@
+{
+  "plecs_version_pinned": "4.7",
+  "files": {
+    "references/components/electrical-passive.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Resistor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Inductor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Capacitor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Transformer.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-sources.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceAC.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceDC.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceControlled.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/CurrentSourceControlled.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-switches.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Mosfet.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Igbt.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Diode.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/SwitchIdeal.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-meters.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Voltmeter.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Ammeter.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Scope.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/magnetic.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/Permeance.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/MmfSource.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/FluxMeter.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/thermal.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/HeatSink.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/ThermalCapacitor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/AmbientTemperature.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/control.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/PIController.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/TransferFunction.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/StateMachine.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/system.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Subsystem.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/ConfigurableSubsystem.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Mask.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/rpc-api.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/XmlRpcInterface.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/plecs-xml-grammar.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/PlecsFileFormat.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/solver.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Simulation/SolverSettings.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/codegen.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/CodeGeneration/Overview.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/cscript.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/CScript.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    }
+  }
+}

--- a/.claude/skills/plecs-expert/manifest.json
+++ b/.claude/skills/plecs-expert/manifest.json
@@ -213,6 +213,12 @@
         "c-scripts-table-0": "e9edf84d99552bcea3fd44b3a7c3232a55925cd0f216d6e4b31bd667231e646c"
       },
       "prose_section_hashes": {}
+    },
+    "references/plecs-xml-grammar.md": {
+      "source_urls": [],
+      "table_section_hashes": {},
+      "prose_section_hashes": {},
+      "_note": "No public docs page; hand-authored from data/*.plecs samples in Task 15. sync_tables.py skips entries with empty source_urls."
     }
   }
 }

--- a/.claude/skills/plecs-expert/manifest.json
+++ b/.claude/skills/plecs-expert/manifest.json
@@ -220,5 +220,27 @@
       "prose_section_hashes": {},
       "_note": "No public docs page; hand-authored from data/*.plecs samples in Task 15. sync_tables.py skips entries with empty source_urls."
     }
+  },
+  "pyplecs_snapshot": {
+    "wrappers": [
+      "CapacitorPlecsMdl",
+      "InductorPlecsMdl",
+      "MosfetWithDiodePlecsMdl",
+      "ResistorPlecsMdl",
+      "TransformerPlecsMdl",
+      "TurnOnDelayPlecsMdl"
+    ],
+    "rpc_methods": [
+      "close",
+      "health_check",
+      "is_available",
+      "load_modelvars",
+      "run_sim_with_datastream",
+      "run_sim_with_mat_file",
+      "set_value",
+      "simulate",
+      "simulate_batch",
+      "simulate_raw"
+    ]
   }
 }

--- a/.claude/skills/plecs-expert/references/codegen.md
+++ b/.claude/skills/plecs-expert/references/codegen.md
@@ -1,0 +1,125 @@
+# codegen
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-table-0 -->
+
+|  | RSim Target | Real-Time Target |
+| --- | --- | --- |
+| Purpose | Rapid, non-real-time simulations. | Real-time simulations. |
+| Technique | A compressed description of the circuit schematic is embedded in the code and interpreted at run time. | Signal and state-space equations are inlined as ANSI C code. |
+| Limitations | None | Limited support for naturally commutated devices and non-linear components. |
+| Inlining | Parameters may be declared tunable, so that they are evaluated at run time. | All parameters are inlined, i.e. evaluated at compile time and embedded into the generated code. |
+| Deployment | Requires distribution of the PLECS RSim module. | Generated code does not have external dependencies. |
+| Licensing | If a PLECS Coder license is available at build time , the generated code will run without a license. Otherwise, a PLECS license is required at run time . | Requires a PLECS Coder license at build time . |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-table-0 -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-table-1 -->
+
+| Platform | Library Files |
+| --- | --- |
+| Windows 64-bit | plecs/bin/win64/plecsrsim.dll |
+| Mac Intel 64-bit | plecs/bin/maci64/libplecsrsim.dylib |
+| Linux 64-bit | plecs/bin/glnxa64/libplecsrsim.so |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-table-1 -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-switching-algorithm -->
+
+| Name | Description |
+| --- | --- |
+| Iterative | PLECS generates code that implements an iterative switching method as described above. As a consequence of the iteration, simulation steps, in which a switching occurs, require more computation time than simulation steps without switching events. This is usually undesirable in real-time simulations because the longest execution time determines the feasible sample rate. |
+| Direct Look-up | Alternatively, PLECS can generate code that determines the proper switch conduction states directly as functions of the current physical model states and inputs and the gate signals of externally controlled switches. In order to generate these direct look-up functions, PLECS must analyze all possible transitions between all possible combinations of conduction states. This increases the computation time of the code generation process but yields nearly uniform execution times of simulation steps with or without switching events. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-switching-algorithm -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-codegenswitchtypes -->
+
+| Name | Description |
+| --- | --- |
+| Ideal switch model | Ideal switches provide an ideal short or open circuit between its two electrical terminals. The ideal switch model adds one or more switching elements to the electrical system, increasing the total number of switching combinations and state-space matrices as described previously. |
+| Non-ideal switch model | A fixed-value resistor in parallel with a controlled current source represents the switching element. The state-space matrices do not change if a non-ideal switch is open or closed because the non-ideal switch resistance is constant. Therefore, non-ideal switches do not increase the total number of switching combinations and are suitable for models with large numbers of switches. Each non-ideal switch includes an internal logic that models forced and natural commutation behavior. The switch state determines the controlled current source’s update rule. When the switch is closed, the current update rule drives the voltage across the switching element to zero. The update rule for an open switch drives the current through the device to zero. The update rules do not result in an ideal short or open circuit. Rather, a closed non-ideal switch behaves like a small inductor and an open non-ideal switch a small capacitor with additional series damping elements. The non-ideal switch resistance and the discretization step size determine the effective inductance and capacitance of the switch. The Non-ideal switch resistance (code generation) parameter in the Simulation Parameters menu (see PLECS Blockset Parameters and PLECS Standalone Parameters ) sets the resistance. The non-zero impedance of an open-circuit non-ideal switch will result in a leakage current through the open switch. In AC systems the leakage current may be unacceptably large at the fundamental frequency. Certain electrical switches, like the Breaker component , offer the capability to increase the effective switch impedance at a defined frequency, thereby blocking a specific AC component of the current through the switch. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-codegenswitchtypes -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-code-generation-with-plecs-standalone -->
+
+| Name | Description |
+| --- | --- |
+| void model_initialize ( double time ) | This function should be called once at the beginning of a simulation to initialize the internal data structures and the start value of the global clock for components that depend on the absolute time. |
+| void model_step () void model_step ( int task_id ) | This function should be called at every simulation step to advance the model by one step. The second form is used if the multi-tasking mode is enabled (see Scheduling ) and the model has more than one task. |
+| void model_output () void model_output ( int task_id ) | This function calculates the outputs of the current simulation step. It should be called at every simulation step before the model_update function. The second form is used if the multi-tasking mode is enabled. |
+| void model_update () void model_update ( int task_id ) | This function updates the internal states of the current simulation step. It should be called at every simulation step after the model_output function. The second form is used if the multi-tasking mode is enabled. |
+| void model_terminate () | This function should be called at the end of a simulation to release resources that were acquired at the beginning of or during a simulation. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-code-generation-with-plecs-standalone -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-general -->
+
+| Name | Description |
+| --- | --- |
+| Discretization method | This parameter specifies the algorithm used to discretize the physical model equations (see Physical Model Discretization ). |
+| Floating point format | This parameter specifies the default data type ( float or double ) that is used for floating point variables in the generated code. |
+| Usage of absolute time | This setting allows you to specify the diagnostic action to be taken if PLECS generates code for a component that depends on the absolute time. In order to minimize round-off errors, PLECS generates code to calculate the absolute time using a signed 64-bit integer tick counter. If a simulation runs for an infinite time, this tick counter will eventually reach its maximum value, where it is halted to avoid problems that might occur if the counter was wrapped to the (negative) minimum value, such as a Step block resetting to its initial value. To put things into perspective, assuming a step size of \(1\,\mu\mathrm{s}\) , this would occur after \(292{,}271\) years. Depending on this setting, PLECS will either ignore this condition or it will issue a warning or error message that indicates the components that use the absolute time. |
+| Base name | This parameter allows you to specify a custom prefix used to name the generated files and the exported symbols such as the interface functions or the input, output and parameter structs. By default, i.e. if you clear this field, the base name is derived from the model or subsystem name. |
+| Output directory | This parameter allows you to specify, where the generated files are stored. This can be an absolute path or a relative path with respect to the location of the model file. The default path is a directory model_codegen next to the model file. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-general -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-parameter-inlining -->
+
+| Name | Description |
+| --- | --- |
+| Default behavior | This setting specifies whether PLECS inlines the parameter values as numeric constants directly into the code ( Inline parameter values ) or generates a data structure from which the values are read ( Keep parameters tunable ). Inlining parameter values reduces the code size and increases the execution speed. However, changing an inlined parameter value requires regenerating and recompiling the code. On the other hand, the values of tunable parameters can be changed at execution time without recompiling the code. |
+| Exceptions | For the components listed here, the opposite of the default behavior applies. If the default behavior is to inline all parameter values, the components listed here will keep their parameters tunable and vice versa. To add components to this list, simply drag them from the schematic into the list. Use the Remove button to remove components from the list. To view the selected component in the schematic editor, click the Show component button. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-parameter-inlining -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-target -->
+
+| Name | Description |
+| --- | --- |
+| Generate separate output and update functions | If you choose this option, the model_step function is replaced by the two functions model_output and model_update . Choose this option when you need access to the outputs as early as possible during task execution (e.g. to transfer the values to an analog or digital output, update a logger, start a DMA transfer, etc.). |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-target -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-scheduling -->
+
+| Name | Description |
+| --- | --- |
+| Tasking mode | This parameter allows you to choose between the single-tasking and multi-tasking modes. |
+| Discretization step size | This parameter specifies the base sample time of the generated code and is used to discretize the physical model equations (see Physical Model Discretization ) and continuous state variables of control blocks. |
+| Task configuration | If you choose the multi-tasking mode, the dialog will show a table that lets you define a set of tasks. A task has a Task name and a Sample time that must be an integer multiple of the base sample time. The value 0 is replaced with the base sample time itself. If the selected target supports multi-core processing, a task is also associated with a Core . If the selected target has multiple processors, a task is also associated with a CPU . The radio buttons in the Default column specify the default task (see below). Each task must have a unique name, and the core/sample time pairs must also be unique. Note that the task set must comprise a base task that is associated with the base sample time and core 0 (if applicable). For this reason, these columns in the first row are locked. To assign a block or a group of blocks to a task, copy a Task Frame into the schematic, open the Task Frame dialog to choose the desired task, and drag the frame around the blocks. Blocks that are not enclosed by a Task Frame are scheduled in the default task . Note that blocks do not need to have the same sample time as the task that they are assigned to; the block sample time can be continuous or an integer multiple of the task sample time. |
+| Thermal model task | In multi-tasking mode you can choose to execute all thermal model calculations in a dedicated task, typically on a separate core with a slower sample time in order to allow for the longer computation time for the calculation of switch losses. This asynchronous execution mode is supported only for power modules in Sub-cycle average configuration. To configure a dedicated thermal model task, select its name in the combo box. The default setting, use native task , means that a thermal model is executed according to the Task Frame configuration synchronously with an associated electrical model. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-scheduling -->
+
+<!-- BEGIN VERBATIM TABLE: codegeneration-simulink-coder-options -->
+
+| Name | Description |
+| --- | --- |
+| Code generation target | This parameter specifies the code generation target (see Code Generation Targets ). The default, auto , means that PLECS selects the target depending on the Simulink Coder target. |
+| Inline circuit parameters for RSim target | Specifies for the RSim target whether component parameters should be evaluated at compile time and inlined into the code ( on ) or evaluated at run time ( off ). See also Tunable Circuit Parameters in Rapid Simulations . |
+| Generate license-free code (requires PLECS Coder license) | If this option is checked, PLECS will attempt to check-out a PLECS Coder license at build time and, if successful, will generate code for the RSim target that will run without requiring a PLECS license. Otherwise, the generated executable will require a PLECS license at run time. |
+| Show code generation progress | If this option is checked, PLECS opens a dialog window during code generation that shows the progress of the code generation process. You can abort the process by clicking the Cancel button or closing the dialog window. |
+
+_Source: https://docs.plexim.com/plecs/latest/codegeneration/_
+
+<!-- END VERBATIM TABLE: codegeneration-simulink-coder-options -->

--- a/.claude/skills/plecs-expert/references/codegen.md
+++ b/.claude/skills/plecs-expert/references/codegen.md
@@ -1,5 +1,9 @@
 # codegen
 
+PLECS Coder generates ANSI C from a schematic. Two targets: RSim (rapid sim, interpreted parameters) and Real-Time (inlined). Not wrapped in pyplecs — drive code-gen via PLECS GUI or direct RPC `plecs_rpc('plecs.generateCode', ...)`.
+
+## Targets at a glance
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-table-0 -->
 
 |  | RSim Target | Real-Time Target |
@@ -15,6 +19,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-table-0 -->
 
+### Notes
+- RSim ships everywhere with no extra deps but needs the RSim runtime DLL.
+- Real-Time embeds zero deps in the C output. Best for HIL targets.
+
+## RSim runtime libraries
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-table-1 -->
 
 | Platform | Library Files |
@@ -27,6 +37,13 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-table-1 -->
 
+### Notes
+- Ship the platform DLL/dylib/so next to the generated code when deploying RSim.
+
+## Switching algorithm
+
+How the coder resolves switch transitions in generated C. Iterative: small code, variable per-step time. Direct Look-up: bigger code, uniform per-step time.
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-switching-algorithm -->
 
 | Name | Description |
@@ -38,6 +55,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-switching-algorithm -->
 
+### Notes
+- Direct Look-up scales as O(2^n) over n switches in build time. Use for small switching topologies on real-time targets.
+- Iterative scales linearly in build time. Variable execution time per step.
+
+## Switch model in generated code
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-codegenswitchtypes -->
 
 | Name | Description |
@@ -48,6 +71,14 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-codegenswitchtypes -->
+
+### Notes
+- Ideal model = combinatorial state-space matrix per switching combination.
+- Non-ideal model = constant matrix; cheap for many switches but adds leakage.
+
+## Generated C entry points
+
+The PLECS-Standalone code-gen output exposes these C functions. Wrap them in a sample-time loop on the target.
 
 <!-- BEGIN VERBATIM TABLE: codegeneration-code-generation-with-plecs-standalone -->
 
@@ -63,6 +94,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-code-generation-with-plecs-standalone -->
 
+### Notes
+- Loop order: `model_initialize` → repeat (`model_output`, `model_update` OR single `model_step`) → `model_terminate`.
+- Split output/update needed for low-latency I/O paths (DMA, DAC).
+
+## General code-gen options
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-general -->
 
 | Name | Description |
@@ -77,6 +114,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-general -->
 
+### Notes
+- Default output dir = `<model>_codegen` next to `.plecs` file.
+- Float vs double: pick float on MCU FPUs without 64-bit support.
+
+## Parameter inlining
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-parameter-inlining -->
 
 | Name | Description |
@@ -88,6 +131,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-parameter-inlining -->
 
+### Notes
+- Inline = smaller, faster, recompile to retune.
+- Tunable = larger, slower, runtime-writable struct.
+
+## Target options
+
 <!-- BEGIN VERBATIM TABLE: codegeneration-target -->
 
 | Name | Description |
@@ -97,6 +146,8 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-target -->
+
+## Scheduling — multi-tasking
 
 <!-- BEGIN VERBATIM TABLE: codegeneration-scheduling -->
 
@@ -110,6 +161,12 @@ _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 _Source: https://docs.plexim.com/plecs/latest/codegeneration/_
 
 <!-- END VERBATIM TABLE: codegeneration-scheduling -->
+
+### Notes
+- Multi-tasking spawns one C task per row in the table.
+- Sample time per task = integer multiple of base step. 0 means base.
+
+## Simulink Coder options (Blockset)
 
 <!-- BEGIN VERBATIM TABLE: codegeneration-simulink-coder-options -->
 

--- a/.claude/skills/plecs-expert/references/components/control.md
+++ b/.claude/skills/plecs-expert/references/components/control.md
@@ -1,0 +1,117 @@
+# control
+
+<!-- BEGIN VERBATIM TABLE: continuouspidcontroller-anti-windup-methods -->
+
+| Name | Description |
+| --- | --- |
+| Back-Calculation | The Back-calculation method changes the integral action when the controller output is in saturation. The integral term is reduced/increased when the controller output is higher/lower than the upper/lower saturation limit. This is done by feeding back the difference between the saturated and the unsaturated controller output. The value of the back-calculation gain \(K_\mathrm{bc}\) determines the rate at which the integrator is reset and is therefore crucial for performance of the anti-windup mechanism. A common choice for this back-calculation gain is: \[K_\mathrm{bc} = \sqrt{\frac{K_\mathrm{i}}{K_\mathrm{d}}}.\] However, this rule can only be applied to full PID controllers. In the case of a PI controller, where \(K_\mathrm{d} = 0\) , it is suggested that \[K_\mathrm{bc} = \frac{K_\mathrm{i}}{K_\mathrm{p}}.\] |
+| Conditional Integration | The Conditional integration method stops the integration when the controller output saturates and the control error \(e\) and the control variable \(u\) have the same sign. This means, the integral action is still applied if it helps to push the controller output out of saturation. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/_
+
+<!-- END VERBATIM TABLE: continuouspidcontroller-anti-windup-methods -->
+
+<!-- BEGIN VERBATIM TABLE: continuouspidcontroller-anti-windup-methods-2 -->
+
+| Name | Description |
+| --- | --- |
+| Anti-Windup with External Saturation | If the saturation is placed externally to the PID controller block, i.e. Saturation is set to external , one can still use the above described anti-windup methods. To feedback the saturated output of the external Saturation block an additional subsystem port \(u^*\) is made visible if the Saturation parameter is set to external and the Anti-windup method parameters is set to an option other than none , see the figure below. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/_
+
+<!-- END VERBATIM TABLE: continuouspidcontroller-anti-windup-methods-2 -->
+
+<!-- BEGIN VERBATIM TABLE: continuouspidcontroller-basic -->
+
+| Name | Description |
+| --- | --- |
+| Controller type | Specifies the controller type. The controller can be of type P , I , PI , PD or PID . |
+| Parameter source | Specifies whether the controller parameters are provided via the mask parameters ( internal ) or via input signals ( external ). |
+| Proportional gain Kp | The proportional gain of the controller. This parameter is shown only if the Controller type parameter is set to P , PI , PD or PID and the Parameter source parameter is set to internal . |
+| Integral gain Ki | The integral gain of the controller. This parameter is shown only if the Controller type parameter is set to I , PI or PID and the Parameter source parameter is set to internal . |
+| Derivative gain Kd | The derivative gain of the controller. This parameter is shown only if the Controller type parameter is set to PD or PID and the Parameter source parameter is set to internal . |
+| Derivative filter coefficient Kf | The filter coefficient which specifies the pole location of the first-order filter in the derivative term. This parameter is shown only if the Controller type parameter is set to PD or PID and the Parameter source parameter is set to internal . |
+| External reset | The behavior of the external reset input. The values rising , falling and either cause a reset of the integrator on the rising, falling or both edges of the reset signal. A rising edge is detected when the signal changes from \(0\) to a positive value, a falling edge is detected when the signal changes from a positive value to \(0\) . If level is chosen, the output signal keeps the initial value while the reset input is not \(0\) . Only the integrator in the integral action is reset. |
+| Initial condition source | Specifies wheter the initial condition is provided via the Initial condition parameter ( internal ) or via an input signal ( external ). |
+| Initial condition | The initial condition of the integrator in the integral action. The value may be a scalar or a vector corresponding to the implicit width of the component. This parameter is shown only if the Initial condition source parameter is set to internal . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/_
+
+<!-- END VERBATIM TABLE: continuouspidcontroller-basic -->
+
+<!-- BEGIN VERBATIM TABLE: continuouspidcontroller-anti-windup -->
+
+| Name | Description |
+| --- | --- |
+| Saturation | Specifies if the internally placed saturation ( internal ) is used or if the user wants to place the saturation externally ( external ) to the Continuous PID Controller block . If external is selected, the internal Saturation block is not active. |
+| Saturation limits | Specifies whether the saturation limits are provided via the mask parameters ( constant ) or via input signals ( variable ). |
+| Upper saturation limit | An upper limit for the output signal. If the value is inf , the output signal is unlimited. If input and output are vectorized, signals a vector can be used. The number of elements in the vector must match the number of input signals. This parameter is shown only if the Saturation parameter is set to internal and the Saturation limits parameter is set to constant . |
+| Lower saturation limit | A lower limit for the output signal. If the value is -inf , the output signal is unlimited. If input and output are vectorized, signals a vector can be used. The number of elements in the vector must match the number of input signals. This parameter is shown only if the Saturation parameter is set to internal and the Saturation limits parameter is set to constant . |
+| Anti-Windup method | Specifies the method to avoid windup of the integral action. See Anti-windup methods above. |
+| Back-calculation gain | The gain of the back-calculation anti-windup method. This parameter is shown only of the Anti-windup method parameter is set to Back-calculation . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/_
+
+<!-- END VERBATIM TABLE: continuouspidcontroller-anti-windup -->
+
+<!-- BEGIN VERBATIM TABLE: continuouspidcontroller-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Proportional action | Proportion of the proportional action of the controller output signal. |
+| Integral action | Proportion of the integral action of the controller output signal. |
+| Derivative action | Proportion of the derivative action of the controller output signal. |
+| Controller output before saturation | The input signal of the saturation block. |
+| Controller output after saturation | The output signal of the saturation block. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/continuouspidcontroller/_
+
+<!-- END VERBATIM TABLE: continuouspidcontroller-probes -->
+
+<!-- BEGIN VERBATIM TABLE: transferfcn-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Numerator coefficients | A vector of the \(s\) term coefficients \([n_n \ldots  n_1, n_0]\) for the numerator, written in descending order of powers of \(s\) . For example, the numerator \(s^3+2s\) would be entered as [1,0,2,0] }. The Transfer Function supports multiple outputs for a single input by entering a matrix for the numerator. Each row of the matrix defines the numerator coefficients of an output. |
+| Denominator coefficients | A vector of the \(s\) term coefficients \([d_n \ldots d_1, d_0]\) for the denominator, written in descending order of powers of \(s\) . Note The order of the denominator (highest power of \(s\) ) must be greater than or equal to the order of the numerator. |
+| Initial condition | The initial condition vector of the internal states of the Transfer Function in the form \([x_n \ldots  x_1, x_0]\) . The initial condition must be specified for the controller normal form, depicted below for the transfer function \[\frac{Y(s)}{U(s)}=\frac{n_2s^2+n_1s+n_0}{d_2s^2+d_1s+d_0} = b_2\left(a_2 + \frac{a_1s + a_0}{s^2 + b_1s + b_0}\right)\] Fig. 161 Transfer function controller normal form  where \[\begin{split}\begin{array}{rcll} b_i & = & \frac{\displaystyle d_i}{\displaystyle d_n} & \mbox{for $i<n$ }\\ b_n & = & \frac{\displaystyle 1}{\displaystyle d_n}\\ a_i & = & n_i - \frac{\displaystyle n_n d_i}{\displaystyle d_n} & \mbox{for $i<n$}\\ a_n & = & n_n \end{array}\end{split}\] For the normalized transfer function (with \(n_n = 0\) and \(d_n = 1\) ) this simplifies to \(b_i = d_i\) and \(a_i = n_i\) . Note The number of internal states is defined by the highest power of \(s\) of the denominator. Note A scalar initial condition will be applied to all internal states. Note In case of scalar expansion (multiple input signals), the initial condition can also be a matrix, where each row defines the initial condition for the individual inputs. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/transferfcn/_
+
+<!-- END VERBATIM TABLE: transferfcn-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: transferfcn-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Input | The input signal. |
+| Output | The output signal. |
+| State | The internal states of the controller normal form. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/transferfcn/_
+
+<!-- END VERBATIM TABLE: transferfcn-probes -->
+
+<!-- BEGIN VERBATIM TABLE: statemachines-table-0 -->
+
+| Macro | Type | Access | Description |
+| --- | --- | --- | --- |
+| CurrentTime | double | R | Returns the current simulation time. |
+| SetErrorMessage ( char * msg ) | void | W | Use this macro to report errors that occur in your code. The simulation will be terminated after the current simulation step. In general, this macro should be followed by a return statement. The pointer msg must point to static memory. |
+| SetWarningMessage ( char * msg ) | void | W | Use this macro to report warnings. The warning status is reset after the execution of the current simulation step, so you do not need to reset it manually. The pointer msg must point to static memory. |
+
+_Source: https://docs.plexim.com/plecs/latest/statemachines/_
+
+<!-- END VERBATIM TABLE: statemachines-table-0 -->
+
+<!-- BEGIN VERBATIM TABLE: statemachines-table-1 -->
+
+| Type | Value |  |
+| --- | --- | --- |
+| Continuous | [0, 0] or 0 |  |
+| Discrete-Periodic | [ T p , T o ] or T p | T p : Sample period, \(0 < {}\) T p T o : Sample offset, \(0 \le{}\) T o \({}<{}\) T p |
+| Inherited | [-1, 0] or -1 |  |
+
+_Source: https://docs.plexim.com/plecs/latest/statemachines/_
+
+<!-- END VERBATIM TABLE: statemachines-table-1 -->

--- a/.claude/skills/plecs-expert/references/components/control.md
+++ b/.claude/skills/plecs-expert/references/components/control.md
@@ -1,5 +1,13 @@
 # control
 
+Note: pyplecs wraps the Turn-On Delay control block as `pyplecs.plecs_components.TurnOnDelayPlecsMdl`. Other control blocks below have no pyplecs wrapper — set parameters via `PlecsServer.set_value` and route signals through Output ports.
+
+## Continuous PID Controller
+
+`Lib/Control/Continuous/Continuous PID Controller`. P / I / PI / PD / PID controller in continuous time with anti-windup. Pins: 1=ref/error in, 2=control out, optional reset/initial-condition/saturation aux ports.
+
+Wrapped in pyplecs: no.
+
 <!-- BEGIN VERBATIM TABLE: continuouspidcontroller-anti-windup-methods -->
 
 | Name | Description |
@@ -68,13 +76,24 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/continuousp
 
 <!-- END VERBATIM TABLE: continuouspidcontroller-probes -->
 
+### Notes
+- Anti-windup options: none, back-calculation, conditional. Pick back-calc for full PID; conditional integration for PI without `K_bc`.
+- External saturation gives access to a `u*` feedback port for proper anti-windup.
+- Reset edge selectable: rising, falling, either, level.
+
+## Transfer Function
+
+`Lib/Control/Continuous/Transfer Function`. Continuous-time LTI block in `s`. Pins: 1=in, 2=out.
+
+Wrapped in pyplecs: no.
+
 <!-- BEGIN VERBATIM TABLE: transferfcn-parameters -->
 
 | Name | Description |
 | --- | --- |
 | Numerator coefficients | A vector of the \(s\) term coefficients \([n_n \ldots  n_1, n_0]\) for the numerator, written in descending order of powers of \(s\) . For example, the numerator \(s^3+2s\) would be entered as [1,0,2,0] }. The Transfer Function supports multiple outputs for a single input by entering a matrix for the numerator. Each row of the matrix defines the numerator coefficients of an output. |
 | Denominator coefficients | A vector of the \(s\) term coefficients \([d_n \ldots d_1, d_0]\) for the denominator, written in descending order of powers of \(s\) . Note The order of the denominator (highest power of \(s\) ) must be greater than or equal to the order of the numerator. |
-| Initial condition | The initial condition vector of the internal states of the Transfer Function in the form \([x_n \ldots  x_1, x_0]\) . The initial condition must be specified for the controller normal form, depicted below for the transfer function \[\frac{Y(s)}{U(s)}=\frac{n_2s^2+n_1s+n_0}{d_2s^2+d_1s+d_0} = b_2\left(a_2 + \frac{a_1s + a_0}{s^2 + b_1s + b_0}\right)\] Fig. 161 Transfer function controller normal form  where \[\begin{split}\begin{array}{rcll} b_i & = & \frac{\displaystyle d_i}{\displaystyle d_n} & \mbox{for $i<n$ }\\ b_n & = & \frac{\displaystyle 1}{\displaystyle d_n}\\ a_i & = & n_i - \frac{\displaystyle n_n d_i}{\displaystyle d_n} & \mbox{for $i<n$}\\ a_n & = & n_n \end{array}\end{split}\] For the normalized transfer function (with \(n_n = 0\) and \(d_n = 1\) ) this simplifies to \(b_i = d_i\) and \(a_i = n_i\) . Note The number of internal states is defined by the highest power of \(s\) of the denominator. Note A scalar initial condition will be applied to all internal states. Note In case of scalar expansion (multiple input signals), the initial condition can also be a matrix, where each row defines the initial condition for the individual inputs. |
+| Initial condition | The initial condition vector of the internal states of the Transfer Function in the form \([x_n \ldots  x_1, x_0]\) . The initial condition must be specified for the controller normal form, depicted below for the transfer function \[\frac{Y(s)}{U(s)}=\frac{n_2s^2+n_1s+n_0}{d_2s^2+d_1s+d_0} = b_2\left(a_2 + \frac{a_1s + a_0}{s^2 + b_1s + b_0}\right)\] Fig. 161 Transfer function controller normal form  where \[\begin{split}\begin{array}{rcll} b_i & = & \frac{\displaystyle d_i}{\displaystyle d_n} & \mbox{for $i<n$ }\\ b_n & = & \frac{\displaystyle 1}{\displaystyle d_n}\\ a_i & = & n_i - \frac{\displaystyle n_n d_i}{\displaystyle d_n} & \mbox{for $i<n$}\\ a_n & = & n_n \end{array}\end{split}\] For the normalized transfer function (with \(n_n = 0\) and \(d_n = 1\) ) this simplifies to \(b_i = d_i\) and \(a_i = n_i\) . Note The number of internal states is defined by the highest power of \(s\) of the denominator. Note A scalar initial condition will be applied to all internal states. Note In case of scalar expansion (multiple input signals), the initial condition can also be a matrix, where each row defines the initial condition for the individual inputs. |
 
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/transferfcn/_
 
@@ -91,6 +110,17 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/transferfcn
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/transferfcn/_
 
 <!-- END VERBATIM TABLE: transferfcn-probes -->
+
+### Notes
+- Coefficients descending order of `s`. Pad zeros for missing terms (e.g. `s^3 + 2s` → `[1 0 2 0]`).
+- Denominator order ≥ numerator order. Required for proper transfer function.
+- Multi-output via matrix numerator: row per output.
+
+## State Machine
+
+`Lib/Control/State Machine`. Discrete event-driven FSM with C-code transition logic.
+
+Wrapped in pyplecs: no.
 
 <!-- BEGIN VERBATIM TABLE: statemachines-table-0 -->
 
@@ -115,3 +145,7 @@ _Source: https://docs.plexim.com/plecs/latest/statemachines/_
 _Source: https://docs.plexim.com/plecs/latest/statemachines/_
 
 <!-- END VERBATIM TABLE: statemachines-table-1 -->
+
+### Notes
+- Sample-time conventions same as elsewhere in PLECS: -1 inherit, 0 continuous, [Tp Toff] discrete.
+- `SetErrorMessage` aborts after the current step. Pair with a `return` statement.

--- a/.claude/skills/plecs-expert/references/components/electrical-meters.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-meters.md
@@ -1,0 +1,58 @@
+# electrical-meters
+
+<!-- BEGIN VERBATIM TABLE: voltmeter-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Measured voltage | The measured voltage in volts \((\mathrm{V})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/voltmeter/_
+
+<!-- END VERBATIM TABLE: voltmeter-probes -->
+
+<!-- BEGIN VERBATIM TABLE: ammeter-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Measured current | The measured current in amperes ( \(\mathrm{A}\) ). |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/ammeter/_
+
+<!-- END VERBATIM TABLE: ammeter-probes -->
+
+<!-- BEGIN VERBATIM TABLE: scope-scope-setup -->
+
+| Name | Description |
+| --- | --- |
+| Number of plots | This parameter specifies the number of plots shown in the scope window. Each plot corresponds to a terminal on the outside of the block. For each plot, a tab is displayed in the lower part of the dialog where the plot settings can be edited. |
+| Sample time | A scalar specifying the sampling period or a two-element vector specifying the sampling period and offset, in seconds \((\mathrm{s})\) , used to sample the input signals. The default is -1 (inherited). Other valid settings are 0 (continuous) or a valid fixed-step discrete sample time pair. See also section Sample Times . |
+| Limit samples | If this option is selected, the PLECS scope will only save the last \(n\) sample values during a simulation. It can be used in long simulations to limit the amount of memory that is used by PLECS. If the option is unchecked, all sample values are stored in memory. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/scope/_
+
+<!-- END VERBATIM TABLE: scope-scope-setup -->
+
+<!-- BEGIN VERBATIM TABLE: scope-time-axis-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Display time axis | The time axis is either shown underneath each plot or underneath the last plot only. |
+| Time axis label | The time axis label is shown below the time axis in the scope. |
+| Time range | The time range value determines the initial time range that is displayed in the scope, in seconds \((\mathrm{s})\) . If set to auto , the simulation time range is used. |
+| Scrolling mode | The scrolling mode determines the way in which the x-axis is scrolled if during a simulation the current simulation time goes beyond the right x-axis limit. In the paged mode, the plots are cleared when the simulation time reaches the right limit and the x-axis is scrolled by one full x-axis span, i.e. the former right limit becomes the new left limit. In the continuous mode, the plots are continuously scrolled so that new data is always drawn at the right plot border. Note that this mode may affect runtime performance as it causes frequent updates of relatively large screen areas. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/scope/_
+
+<!-- END VERBATIM TABLE: scope-time-axis-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: scope-individual-plot-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Title | The name which is displayed above the plot. |
+| Axis label | The axis label is displayed on the left of the y-axis. |
+| Y-limits | The initial lower and upper bound of the y-axis. If set to auto , the y-axis limits are automatically chosen based on the minimum and maximum curve value in the visible time range. If you check the Keep baseline option, the limits are chosen so that the specified baseline value is always included. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/scope/_
+
+<!-- END VERBATIM TABLE: scope-individual-plot-parameters -->

--- a/.claude/skills/plecs-expert/references/components/electrical-meters.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-meters.md
@@ -1,5 +1,13 @@
 # electrical-meters
 
+## Voltmeter
+
+`Lib/Electrical/Meters/Voltmeter`. Reads voltage between two electrical nodes. Pins: 1=p, 2=n, 3=signal out. Sign: V_out = V_p − V_n.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (PLECS-specific instrumentation).
+
 <!-- BEGIN VERBATIM TABLE: voltmeter-probes -->
 
 | Probe signal | Description |
@@ -10,6 +18,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/voltmeter/_
 
 <!-- END VERBATIM TABLE: voltmeter-probes -->
 
+### Notes
+- No parameters. Outputs control-domain signal.
+- Use a wire from the signal port to a Scope or controller block.
+
+## Ammeter
+
+`Lib/Electrical/Meters/Ammeter`. Reads current through a series branch. Pins: 1=p, 2=n, 3=signal out. Sign: I_out flows p→n.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (PLECS-specific instrumentation).
+
 <!-- BEGIN VERBATIM TABLE: ammeter-probes -->
 
 | Probe signal | Description |
@@ -19,6 +39,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/voltmeter/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/ammeter/_
 
 <!-- END VERBATIM TABLE: ammeter-probes -->
+
+### Notes
+- Inserts in series. Acts as a zero-impedance branch.
+- For loss-free measurement use ammeter, not a small resistor.
+
+## Scope
+
+`Lib/System/Scope`. Multi-channel time-series viewer. Pins: 1..N=signal in.
+
+Wrapped in pyplecs: no (data extraction goes through PlecsProbe + datastream RPC).
+
+SPICE map: n/a (PLECS-specific instrumentation).
 
 <!-- BEGIN VERBATIM TABLE: scope-scope-setup -->
 
@@ -56,3 +88,8 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/scope/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/scope/_
 
 <!-- END VERBATIM TABLE: scope-individual-plot-parameters -->
+
+### Notes
+- Sample time -1 = inherit. 0 = continuous. Pair of [Tp Toff] = discrete.
+- Limit samples option drops oldest data once cap is hit. Use in long sims.
+- For programmatic readout, route signals to Output ports and use `simulate` RPC.

--- a/.claude/skills/plecs-expert/references/components/electrical-passive.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-passive.md
@@ -1,5 +1,13 @@
 # electrical-passive
 
+## Resistor
+
+`Lib/Electrical/Passive Components/Resistor`. Linear ohmic dissipator. Pins: 1=p, 2=n. Sign: i flows p→n.
+
+Wrapped in pyplecs: yes — `pyplecs.plecs_components.ResistorPlecsMdl`.
+
+SPICE map: `R<name> p n {R}`.
+
 <!-- BEGIN VERBATIM TABLE: resistor-parameters -->
 
 | Name | Description |
@@ -21,6 +29,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/resistor/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/resistor/_
 
 <!-- END VERBATIM TABLE: resistor-probes -->
+
+### Notes
+- Vector form `[R_1 R_2 ... R_n]` builds n parallel scalar resistors with shared width.
+- Power probe = `v_R * i_R`. Sign matches passive convention.
+
+## Inductor
+
+`Lib/Electrical/Passive Components/Inductor`. Stores magnetic energy. Pins: 1=p, 2=n. Sign: i_L flows p→n.
+
+Wrapped in pyplecs: yes — `pyplecs.plecs_components.InductorPlecsMdl`.
+
+SPICE map: `L<name> p n {L} IC={IL_init}`.
 
 <!-- BEGIN VERBATIM TABLE: inductor-parameters -->
 
@@ -44,6 +64,19 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/inductor/_
 
 <!-- END VERBATIM TABLE: inductor-probes -->
 
+### Notes
+- Initial current `IL_init` requires UIC in the `.tran` directive on SPICE side.
+- Pin order matters for sign of `i_L` probe.
+- Coupled inductors use a matrix `L`. Off-diagonal entries are mutual inductances `M_ij`.
+
+## Capacitor
+
+`Lib/Electrical/Passive Components/Capacitor`. Stores electric energy. Pins: 1=p (marked +), 2=n. Sign: v_C measured + over −.
+
+Wrapped in pyplecs: yes — `pyplecs.plecs_components.CapacitorPlecsMdl`.
+
+SPICE map: `C<name> p n {C} IC={V_init}`.
+
 <!-- BEGIN VERBATIM TABLE: capacitor-parameters -->
 
 | Name | Description |
@@ -66,6 +99,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/capacitor/_
 
 <!-- END VERBATIM TABLE: capacitor-probes -->
 
+### Notes
+- Initial voltage `V_init` requires UIC in `.tran` on SPICE side.
+- Coupled capacitors use a square matrix; matrix must be invertible.
+
+## Transformer
+
+`Lib/Electrical/Passive Components/Transformer`. Multi-winding magnetic coupling with finite magnetizing inductance. Pins: depend on `[w1 w2]`.
+
+Wrapped in pyplecs: yes — `pyplecs.plecs_components.TransformerPlecsMdl`.
+
+SPICE map: two coupled `L` lines plus `K<name> Lp Ls {coupling}`.
+
 <!-- BEGIN VERBATIM TABLE: transformer-parameters -->
 
 | Name | Description |
@@ -79,3 +124,8 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/capacitor/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/transformer/_
 
 <!-- END VERBATIM TABLE: transformer-parameters -->
+
+### Notes
+- Magnetizing inductance referred to first winding. Set inf for ideal transformer.
+- Polarity vector controls dot orientation per winding.
+- Initial magnetizing current must be 0 when L_m = inf.

--- a/.claude/skills/plecs-expert/references/components/electrical-passive.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-passive.md
@@ -1,0 +1,81 @@
+# electrical-passive
+
+<!-- BEGIN VERBATIM TABLE: resistor-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Resistance | The resistance in ohms \((\Omega)\) . All positive and negative values are accepted, including 0 and inf ( \(\infty\) ). The default is 1 . In a vectorized component, all internal resistors have the same resistance if the parameter is a scalar. To specify the resistances individually use a vector \(\left[ R_1\; R_2 \ldots R_n\right]\) . The length \(n\) of the vector determines the width of the component. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/resistor/_
+
+<!-- END VERBATIM TABLE: resistor-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: resistor-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Resistor voltage | The voltage measured across the resistor from the positive to the negative terminal, in volts ( \(V\) ). |
+| Resistor current | The current flowing through the resistor, in amperes ( \(A\) ). A current entering the resistor at the positive terminal is counted positive. |
+| Resistor power | The power consumed by the resistor, in watts ( \(W\) ). |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/resistor/_
+
+<!-- END VERBATIM TABLE: resistor-probes -->
+
+<!-- BEGIN VERBATIM TABLE: inductor-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Inductance | The inductance in henries \((\mathrm{H})\) . All finite positive and negative values are accepted, including 0 . The default is 0.001 . In a vectorized component, all internal inductors have the same inductance if the parameter is a scalar. To specify the inductances individually use a vector \([ L_1\; L_2 \ldots L_n]\) . The length \(n\) of the vector determines the component’s  width: \[\begin{split}\begin{bmatrix} v_1 \\ v_2 \\ \vdots \\ v_n \end{bmatrix} = \begin{bmatrix} L_{1} & 0 & \cdots & 0 \\ 0 & L_{2} & \cdots & 0 \\ \vdots & \vdots & \ddots & \vdots \\ 0 & 0 & \cdots & L_{n} \end{bmatrix} \begin{bmatrix} \frac{d}{dt} i_1\\ \frac{d}{dt} i_2\\ \vdots \\ \frac{d}{dt} i_n \end{bmatrix}\end{split}\] In order to model a magnetic coupling between the internal inductors enter a square matrix. The size \(n\) of the matrix corresponds to the width of the component. \(L_{i}\) is the self inductance of the internal inductor and \(M_{i,j}\) the mutual inductance: \[\begin{split}\begin{bmatrix} v_1 \\ v_2 \\ \vdots \\ v_n \end{bmatrix} = \begin{bmatrix} L_{1} & M_{1,2} & \cdots & M_{1,n} \\ M_{2,1} & L_{2} & \cdots & M_{2,n} \\ \vdots & \vdots & \ddots & \vdots \\ M_{n,1} & M_{n,2} & \cdots & L_{n} \end{bmatrix} \begin{bmatrix} \frac{d}{dt} i_1\\ \frac{d}{dt} i_2\\ \vdots \\ \frac{d}{dt} i_n \end{bmatrix}\end{split}\] The inductance matrix must be invertible, i.e. it may not be singular. A singular inductance matrix results for example when two or more inductors are ideally coupled. To model this, use an inductor in parallel with an Ideal Transformer . The relationship between the coupling factor \(k_{i,j}\) and the mutual inductance \(M_{i,j}\) is \[M_{i,j} = M_{j,i} = k_{i,j} \sqrt{L_i \cdot L_j}\] |
+| Initial current | The initial current through the inductor at simulation start, in amperes \((\mathrm{A})\) . This parameter may either be a scalar or a vector corresponding to the width of the component. The direction of a positive initial current is indicated by a small arrow in the component symbol. The default of the initial current is 0 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/inductor/_
+
+<!-- END VERBATIM TABLE: inductor-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: inductor-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Inductor current | The current flowing through the inductor, in amperes \((\mathrm{A})\) . The direction of a positive current is indicated with a small arrow in the component symbol. |
+| Inductor voltage | The voltage measured across the inductor, in volts \((\mathrm{V})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/inductor/_
+
+<!-- END VERBATIM TABLE: inductor-probes -->
+
+<!-- BEGIN VERBATIM TABLE: capacitor-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Capacitance | The value of the capacitor, in farads \((\mathrm{F})\) . All finite positive and negative values are accepted, including 0 . The default is 100e-6 . In a vectorized component, all internal capacitors have the same value if the parameter is a scalar. To specify the capacitances individually use a vector \([ C_1\; C_2 \ldots C_n]\) . The length \(n\) of the vector determines the component’s width: \[\begin{split}\left[ \begin{array}{c}i_1 \\i_2 \\ \vdots \\i_n \\ \end{array} \right] \; = \; \left[ \begin{array}{cccc} C_{1} & 0 & \cdots & 0 \\ 0 & C_{2} & \cdots & 0 \\ \vdots & \vdots & \ddots & \vdots \\ 0 & 0 & \cdots & C_{n} \\ \end{array} \right] \cdot \left[ \begin{array}{c} \frac{d}{dt} v_1\\ \frac{d}{dt} v_2\\ \vdots \\ \frac{d}{dt} v_n\\ \end{array} \right]\end{split}\] In order to model a coupling between the internal capacitors enter a square matrix. The size \(n\) of the matrix corresponds to the width of the component: \[\begin{split}\left[ \begin{array}{c}i_1 \\i_2 \\ \vdots \\i_n \\ \end{array} \right] \; = \; \left[ \begin{array}{cccc} C_{1} & C_{1,2} & \cdots & C_{1,n} \\ C_{2,1} & C_{2} & \cdots & C_{2,n} \\ \vdots & \vdots & \ddots & \vdots \\ C_{n,1} & C_{n,2} & \cdots & C_{n} \\ \end{array} \right] \cdot \left[ \begin{array}{c} \frac{d}{dt} v_1\\ \frac{d}{dt} v_2\\ \vdots \\ \frac{d}{dt} v_n\\ \end{array} \right]\end{split}\] The capacitance matrix must be invertible, i.e. it may not be singular. |
+| Initial voltage | The initial voltage of the capacitor at simulation start, in volts \((\mathrm{V})\) . This parameter may either be a scalar or a vector corresponding to the width of the component. The positive pole is marked with a “+”. The initial voltage default is 0 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/capacitor/_
+
+<!-- END VERBATIM TABLE: capacitor-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: capacitor-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Capacitor voltage | The voltage measured across the capacitor, in volts \((\mathrm{V})\) . A positive voltage is measured when the potential at the terminal marked with “+” is greater than the potential at the unmarked terminal. |
+| Capacitor current | The current flowing through the capacitor, in amperes \((\mathrm{A})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/capacitor/_
+
+<!-- END VERBATIM TABLE: capacitor-probes -->
+
+<!-- BEGIN VERBATIM TABLE: transformer-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Number of windings | A two-element vector \([w_1\; w_2]\) containing the number of windings on the primary side \(w_1\) and on the secondary side \(w_2\) . The default is [1 1] , which represents a two-winding transformer with opposite windings. |
+| Number of turns | A row vector specifying the number of turns for each winding. The vector length must match the total number of primary and secondary side windings. First, all primary side windings are specified, followed by the specifications for all secondary side windings. |
+| Polarity | A string consisting of one + or - per winding specifying the winding polarity. A single + or - is applied to all windings. |
+| Magnetizing inductance | A non-zero scalar specifying the magnetizing inductance referred to the first winding, in henries \((\mathrm{H})\) . |
+| Initial magnetizing current | A scalar specifying the initial current through the magnetizing inductance at simulation start, in amperes \((\mathrm{A})\) . Must be zero if the magnetizing inductance is infinite inf . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/transformer/_
+
+<!-- END VERBATIM TABLE: transformer-parameters -->

--- a/.claude/skills/plecs-expert/references/components/electrical-sources.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-sources.md
@@ -1,5 +1,13 @@
 # electrical-sources
 
+## AC Voltage Source
+
+`Lib/Electrical/Sources/AC Voltage Source`. Sinusoidal voltage source. Pins: 1=p, 2=n. Sign: v = A·sin(ω·t + φ).
+
+Wrapped in pyplecs: no.
+
+SPICE map: `V<name> p n SIN(0 {A} {f} 0 0 {phi_deg})`.
+
 <!-- BEGIN VERBATIM TABLE: acvoltagesource-parameters -->
 
 | Name | Description |
@@ -24,6 +32,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/acvoltageso
 
 <!-- END VERBATIM TABLE: acvoltagesource-probes -->
 
+### Notes
+- Frequency parameter is angular (rad/s), not Hz. Use `2*pi*f_hz` for Hz input.
+- Default 2*pi*50 → 50 Hz mains.
+
+## DC Voltage Source
+
+`Lib/Electrical/Sources/DC Voltage Source`. Ideal constant voltage source. Pins: 1=p, 2=n.
+
+Wrapped in pyplecs: no.
+
+SPICE map: `V<name> p n {V}`.
+
 <!-- BEGIN VERBATIM TABLE: dcvoltagesource-parameters -->
 
 | Name | Description |
@@ -45,6 +65,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/dcvoltageso
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/dcvoltagesource/_
 
 <!-- END VERBATIM TABLE: dcvoltagesource-probes -->
+
+### Notes
+- Vector form widens component into n parallel scalar sources.
+- In `.plecs` file Type=`DCVoltageSource`, parameter Variable="V".
+
+## Controlled Voltage Source
+
+`Lib/Electrical/Sources/Controlled Voltage Source`. Voltage = signal input. Pins: 1=p, 2=n, 3=signal in.
+
+Wrapped in pyplecs: no.
+
+SPICE map: `B<name> p n V={signal}` (behavioral source).
 
 <!-- BEGIN VERBATIM TABLE: controlledvoltagesource-parameters -->
 
@@ -69,6 +101,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledv
 
 <!-- END VERBATIM TABLE: controlledvoltagesource-probes -->
 
+### Notes
+- Discretization sets ZOH vs FOH on input signal.
+- State-space inlining = expert flag. Default off.
+
+## Controlled Current Source
+
+`Lib/Electrical/Sources/Controlled Current Source`. Current = signal input. Pins: 1=p, 2=n, 3=signal in. Sign: i flows p→n.
+
+Wrapped in pyplecs: no.
+
+SPICE map: `B<name> p n I={signal}` (behavioral source).
+
 <!-- BEGIN VERBATIM TABLE: controlledcurrentsource-parameters -->
 
 | Name | Description |
@@ -91,3 +135,7 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledc
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledcurrentsource/_
 
 <!-- END VERBATIM TABLE: controlledcurrentsource-probes -->
+
+### Notes
+- Same discretization options as controlled voltage source.
+- Probes report measured V across the source plus injected I.

--- a/.claude/skills/plecs-expert/references/components/electrical-sources.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-sources.md
@@ -1,0 +1,93 @@
+# electrical-sources
+
+<!-- BEGIN VERBATIM TABLE: acvoltagesource-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Amplitude | The amplitude \(A\) of the voltage, in volts \((\mathrm{V})\) . The default is 1 . |
+| Frequency | The angular frequency \(\omega\) , in \(\left( \frac{\mathrm{rad}}{\mathrm{s}} \right)\) . The default is 2*pi*50 which corresponds to \(50\,\mathrm{Hz}\) . |
+| Phase | The phase shift \(\varphi\) , in radians. The default is 0 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/acvoltagesource/_
+
+<!-- END VERBATIM TABLE: acvoltagesource-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: acvoltagesource-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Source voltage | The source voltage in volts \((\mathrm{V})\) . |
+| Source current | The current flowing through the source, in amperes \((\mathrm{A})\) . |
+| Source power | The instantaneous output power of the source, in watts \((\mathrm{W})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/acvoltagesource/_
+
+<!-- END VERBATIM TABLE: acvoltagesource-probes -->
+
+<!-- BEGIN VERBATIM TABLE: dcvoltagesource-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Voltage | The magnitude of the constant voltage, in volts \((\mathrm{V})\) . This parameter may either be a scalar or a vector defining the width of the component. The default value is 1 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/dcvoltagesource/_
+
+<!-- END VERBATIM TABLE: dcvoltagesource-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: dcvoltagesource-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Source voltage | The source voltage in volts \((\mathrm{V})\) . |
+| Source current | The current flowing through the source, in amperes \((\mathrm{A})\) . |
+| Source power | The instantaneous output power of the source, in watts \((\mathrm{W})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/dcvoltagesource/_
+
+<!-- END VERBATIM TABLE: dcvoltagesource-probes -->
+
+<!-- BEGIN VERBATIM TABLE: controlledvoltagesource-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Discretization behavior | Specifies whether a zero-order hold or a first-order hold is applied to the input signal when the model is discretized. For details, see Physical Model Discretization . The option Non-causal zero-order hold applies a zero-order hold with the input signal value from the current simulation step instead of the previous one. This option can be used to compensate for a known delay of the input signal. |
+| Allow state-space inlining | For expert use only! When set to on and the input signal is a linear combination of electrical measurements, PLECS will eliminate the input variable from the state-space equations and substitute it with the corresponding output variables. The default is off . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledvoltagesource/_
+
+<!-- END VERBATIM TABLE: controlledvoltagesource-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: controlledvoltagesource-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Source voltage | The source voltage in volts \((\mathrm{V})\) . |
+| Source current | The current flowing through the source, in amperes \((\mathrm{A})\) . |
+| Source power | The instantaneous output power of the source, in watts \((\mathrm{W})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledvoltagesource/_
+
+<!-- END VERBATIM TABLE: controlledvoltagesource-probes -->
+
+<!-- BEGIN VERBATIM TABLE: controlledcurrentsource-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Discretization behavior | Specifies whether a zero-order hold or a first-order hold is applied to the input signal when the model is discretized. For details, see Physical Model Discretization . The option Non-causal zero-order hold applies a zero-order hold with the input signal value from the current simulation step instead of the previous one. This option can be used to compensate for a known delay of the input signal. |
+| Allow state-space inlining | For expert use only! When set to on and the input signal is a linear combination of electrical measurements, PLECS will eliminate the input variable from the state-space equations and substitute it with the corresponding output variables. The default is off . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledcurrentsource/_
+
+<!-- END VERBATIM TABLE: controlledcurrentsource-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: controlledcurrentsource-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Source current | The source current in amperes \((\mathrm{A})\) . |
+| Source voltage | The voltage measured across the source, in volts \((\mathrm{V})\) . |
+| Source power | The instantaneous output power of the source, in watts \((\mathrm{W})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/controlledcurrentsource/_
+
+<!-- END VERBATIM TABLE: controlledcurrentsource-probes -->

--- a/.claude/skills/plecs-expert/references/components/electrical-switches.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-switches.md
@@ -1,0 +1,117 @@
+# electrical-switches
+
+<!-- BEGIN VERBATIM TABLE: mosfet-parameters -->
+
+| Name | Description |
+| --- | --- |
+| On-resistance | The resistance \(R_{\mathrm{on}}\) of the conducting device, in ohms \((\Omega)\) . The default is 0 . |
+| Initial conductivity | Initial conduction state of the MOSFET. The MOSFET is initially blocking if the parameter evaluates to zero, otherwise it is conducting. |
+| Thermal description | Switching losses, conduction losses and thermal equivalent circuit of the component. For more information see chapter Thermal Modeling . If no thermal description is given, the losses are calculated based on the voltage drop \(v_{\mathrm{on}} = R_{\mathrm{on}}\cdot i\) . |
+| Thermal interface resistance | The thermal resistance of the interface material between case and heat sink, in \((\mathrm{K}/\mathrm{W})\) . The default is 0 . |
+| Number of parallel devices | This parameter is used to simulate the effect of connecting multiple identical devices in parallel while adding only one single switch element to the electrical system equations. Other component parameters such as the Thermal description , the Thermal interface resistance and also the electrical On-resistance refer to the characteristics of an individual device, while the calculated losses and other probe signals refer to the sum over all devices. If \(N_\mathrm{p}\) is the number of parallel devices, each device will conduct \(1/N_\mathrm{p}\) of the total current through the component, and the total component loss will be \(N_\mathrm{p}\) times the loss of an individual device. The effective electrical on-resistance and the effective thermal interface resistance of the component are also \(1/N_\mathrm{p}\) times the respective parameter values. The default is 1 . Note If Number of parallel devices is greater than \(1\) , the component itself cannot be vectorized, i.e. all other component parameters must have scalar values, and the component terminals must be connected to a scalar connection (see also Vectorizing Physical Components ). Example Model See the example model “Thermal Modeling with Parallel Devices” . Find it in PLECS under Help > PLECS Documentation > List of Example Models . |
+| Initial temperature | This parameter is used only if the device has an internal thermal impedance and specifies the temperature of the thermal capacitance at the junction at simulation start. The temperatures of the other thermal capacitances are initialized based on a thermal “DC” analysis. If the parameter is left blank, all temperatures are initialized from the external temperature. See also Temperature Initialization . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/mosfet/_
+
+<!-- END VERBATIM TABLE: mosfet-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: mosfet-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| MOSFET voltage | The voltage measured between drain and source. |
+| MOSFET current | The current through the MOSFET flowing from drain to source. |
+| MOSFET gate signal | The gate input signal of the MOSFET. |
+| MOSFET conductivity | Conduction state of the internal switch. The signal outputs \(0\) when the MOSFET is blocking, and \(1\) when it is conducting. |
+| MOSFET junction temperature | Temperature of the first thermal capacitor in the equivalent Cauer network. |
+| MOSFET conduction loss | Continuous thermal conduction losses in watts \((\mathrm{W})\) . Only defined if the component is placed on a heat sink. |
+| MOSFET switching loss | Instantaneous thermal switching losses in joules \((\mathrm{J})\) . Only defined if the component is placed on a heat sink. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/mosfet/_
+
+<!-- END VERBATIM TABLE: mosfet-probes -->
+
+<!-- BEGIN VERBATIM TABLE: igbt-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Forward voltage | Additional dc voltage \(V_\mathrm{f}\) in volts \((\mathrm{V})\) between collector and emitter when the IGBT is conducting. The default is 0 . |
+| On-resistance | The resistance \(R_\mathrm{on}\) of the conducting device, in ohms \((\Omega)\) . The default is 0 . |
+| Initial conductivity | Initial conduction state of the IGBT. The IGBT is initially blocking if the parameter evaluates to zero, otherwise it is conducting. |
+| Thermal description | Switching losses, conduction losses and thermal equivalent circuit of the component. For more information see chapter Thermal Modeling . If no thermal description is given, the losses are calculated based on the voltage drop \(v_\mathrm{on} = V_\mathrm{f} + R_\mathrm{on}\cdot i\) . |
+| Thermal interface resistance | The thermal resistance of the interface material between case and heat sink, in \((\mathrm{K}/\mathrm{W})\) . The default is 0 . |
+| Initial temperature | This parameter is used only if the device has an internal thermal impedance and specifies the temperature of the thermal capacitance at the junction at simulation start. The temperatures of the other thermal capacitances are initialized based on a thermal “DC” analysis. If the parameter is left blank, all temperatures are initialized from the external temperature. See also Temperature Initialization . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/igbt/_
+
+<!-- END VERBATIM TABLE: igbt-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: igbt-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| IGBT voltage | The voltage measured between collector and emitter. |
+| IGBT current | The current through the IGBT flowing from collector to emitter. |
+| IGBT gate signal | The gate input signal of the IGBT. |
+| IGBT conductivity | Conduction state of the internal switch. The signal outputs \(0\) when the IGBT is blocking, and \(1\) when it is conducting. |
+| IGBT junction temperature | Temperature of the first thermal capacitor in the equivalent Cauer network. |
+| IGBT conduction loss | Continuous thermal conduction losses in watts \((\mathrm{W})\) . Only defined if the component is placed on a heat sink. |
+| IGBT switching loss | Instantaneous thermal switching losses in joules \((\mathrm{J})\) . Only defined if the component is placed on a heat sink. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/igbt/_
+
+<!-- END VERBATIM TABLE: igbt-probes -->
+
+<!-- BEGIN VERBATIM TABLE: diode-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Forward voltage | Additional dc voltage \(V_\mathrm{f}\) in volts \((\mathrm{V})\) between anode and cathode when the diode is conducting. The default is 0 . |
+| On-resistance | The resistance \(R_\mathrm{on}\) of the conducting device, in ohms \((\Omega)\) . The default is 0 . |
+| Thermal description | Switching losses, conduction losses and thermal equivalent circuit of the component. For more information see chapter Thermal Modeling . If no thermal description is given, the losses are calculated based on the voltage drop \(v_\mathrm{on} = V_\mathrm{f} + R_\mathrm{on}\cdot i\) . |
+| Thermal interface resistance | The thermal resistance of the interface material between case and heat sink, in \((\mathrm{K}/\mathrm{W})\) . The default is 0 . |
+| Number of parallel devices | This parameter is used to simulate the effect of connecting multiple identical devices in parallel while adding only one single switch element to the electrical system equations. Other component parameters such as the Thermal description , the Thermal interface resistance and also the electrical On-resistance refer to the characteristics of an individual device, while the calculated losses and other probe signals refer to the sum over all devices. If \(N_\mathrm{p}\) is the number of parallel devices, each device will conduct \(1/N_\mathrm{p}\) of the total current through the component, and the total component loss will be \(N_\mathrm{p}\) times the loss of an individual device. The effective electrical on-resistance and the effective thermal interface resistance of the component are also \(1/N_\mathrm{p}\) times the respective parameter values. The default is 1 . Note If Number of parallel devices is greater than \(1\) , the component itself cannot be vectorized, i.e. all other component parameters must have scalar values, and the component terminals must be connected to a scalar connection (see also Vectorizing Physical Components ). Example Model See the example model “Thermal Modeling with Parallel Devices” . Find it in PLECS under Help > PLECS Documentation > List of Example Models . |
+| Initial temperature | This parameter is used only if the device has an internal thermal impedance and specifies the temperature of the thermal capacitance at the junction at simulation start. The temperatures of the other thermal capacitances are initialized based on a thermal “DC” analysis. If the parameter is left blank, all temperatures are initialized from the external temperature. See also Temperature Initialization . |
+| Switch model (CPU code generation) | Select the switch model in the generated code. |
+| Fundamental grid frequency | Frequency where non-ideal switches in the open state have increased series impedance, in hertz \((\mathrm{Hz})\) . The default is 0 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/diode/_
+
+<!-- END VERBATIM TABLE: diode-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: diode-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Diode voltage | The voltage measured between anode and cathode. |
+| Diode current | The current through the diode flowing from anode to cathode. |
+| Diode conductivity | Conduction state of the internal switch. The signal outputs \(0\) when the diode is blocking, and \(1\) when it is conducting. |
+| Diode junction temperature | Temperature of the first thermal capacitor in the equivalent Cauer network. |
+| Diode conduction loss | Continuous thermal conduction losses in watts \((\mathrm{W})\) . Only defined if the component is placed on a heat sink. |
+| Diode switching loss | Instantaneous thermal switching losses in joules \((\mathrm{J})\) . Only defined if the component is placed on a heat sink. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/diode/_
+
+<!-- END VERBATIM TABLE: diode-probes -->
+
+<!-- BEGIN VERBATIM TABLE: switch-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Initial conductivity | Initial conduction state of the switch. The switch is initially open if the parameter evaluates to zero, otherwise closed. This parameter may either be a scalar or a vector corresponding to the implicit width of the component. The default value is 0 . |
+| Switch model (CPU code generation) | Select the switch model in the generated code. |
+| Fundamental grid frequency | Frequency where non-ideal switches in the open state have increased series impedance, in hertz \((\mathrm{Hz})\) . The default is 0 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/switch/_
+
+<!-- END VERBATIM TABLE: switch-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: switch-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Switch conductivity | Conduction state of the switch. The signal outputs \(0\) if the switch is open, and \(1\) if it is closed. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/switch/_
+
+<!-- END VERBATIM TABLE: switch-probes -->

--- a/.claude/skills/plecs-expert/references/components/electrical-switches.md
+++ b/.claude/skills/plecs-expert/references/components/electrical-switches.md
@@ -1,5 +1,13 @@
 # electrical-switches
 
+## MOSFET
+
+`Lib/Electrical/Power Semiconductors/MOSFET`. Externally controlled switch with on-resistance and optional thermal model. Pins: 1=drain, 2=source, 3=gate. Sign: i flows drain→source when on.
+
+Wrapped in pyplecs: yes — `pyplecs.plecs_components.MosfetWithDiodePlecsMdl`.
+
+SPICE map: n/a (ideal-switch model). Closest analog: `M<name> d g s body NMOS` plus parallel body diode.
+
 <!-- BEGIN VERBATIM TABLE: mosfet-parameters -->
 
 | Name | Description |
@@ -31,6 +39,19 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/mosfet/_
 
 <!-- END VERBATIM TABLE: mosfet-probes -->
 
+### Notes
+- pyplecs wrapper covers MOSFET with body diode model.
+- Loss probes (conduction, switching, junction temp) require placement on a Heat Sink.
+- In `.plecs` files Type=`Mosfet`. Parameters: `Ron`, `s_init`, `thermal`, `Rth`, `T_init`.
+
+## IGBT
+
+`Lib/Electrical/Power Semiconductors/IGBT`. Externally controlled switch with forward-voltage drop and on-resistance. Pins: 1=collector, 2=emitter, 3=gate. Sign: i flows C→E when on.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (ideal-switch model).
+
 <!-- BEGIN VERBATIM TABLE: igbt-parameters -->
 
 | Name | Description |
@@ -61,6 +82,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/igbt/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/igbt/_
 
 <!-- END VERBATIM TABLE: igbt-probes -->
+
+### Notes
+- IGBT on-state drop = `V_f + R_on * i`. MOSFET drop = `R_on * i` only.
+- No body diode by default — pair with `IGBT with Diode` block when free-wheel needed.
+
+## Diode
+
+`Lib/Electrical/Power Semiconductors/Diode`. Self-commutated rectifier. Pins: 1=anode, 2=cathode. Sign: i flows A→K when forward-biased.
+
+Wrapped in pyplecs: no.
+
+SPICE map: `D<name> p n DMOD`.
 
 <!-- BEGIN VERBATIM TABLE: diode-parameters -->
 
@@ -94,6 +127,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/diode/_
 
 <!-- END VERBATIM TABLE: diode-probes -->
 
+### Notes
+- Self-commutated. Turn-on threshold set globally via `TurnOnThreshold` solver param.
+- In `.plecs` Type=`Diode`. Parameters: `Vf`, `Ron`, `thermal`, `Rth`, `T_init`.
+
+## Switch (ideal)
+
+`Lib/Electrical/Switches/Switch`. Externally controlled ideal short/open. Pins: 1=p, 2=n, 3=control.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (ideal-switch model).
+
 <!-- BEGIN VERBATIM TABLE: switch-parameters -->
 
 | Name | Description |
@@ -115,3 +160,7 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/switch/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/switch/_
 
 <!-- END VERBATIM TABLE: switch-probes -->
+
+### Notes
+- Lossless. No `Ron`, no `Vf`. Use MOSFET/IGBT for non-ideal modeling.
+- Control input >0 closes the switch.

--- a/.claude/skills/plecs-expert/references/components/magnetic.md
+++ b/.claude/skills/plecs-expert/references/components/magnetic.md
@@ -1,5 +1,13 @@
 # magnetic
 
+## Magnetic Permeance
+
+`Lib/Magnetic/Permeance`. Magnetic-domain analog of capacitance. Pins: 1=marked, 2=unmarked. Sign: flux Φ flows marked→unmarked.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: magneticpermeance-parameters -->
 
 | Name | Description |
@@ -22,6 +30,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/magneticper
 
 <!-- END VERBATIM TABLE: magneticpermeance-probes -->
 
+### Notes
+- Permeance P = 1/Reluctance. Units Wb/A. Larger P = easier flux flow.
+- Magnetic-domain dual: MMF↔V, flux-rate↔I, permeance↔C.
+
+## Constant MMF
+
+`Lib/Magnetic/Constant MMF`. Ideal magneto-motive-force source. Pins: 1=marked, 2=unmarked.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: constantmmf-parameters -->
 
 | Name | Description |
@@ -42,6 +62,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/constantmmf
 
 <!-- END VERBATIM TABLE: constantmmf-probes -->
 
+### Notes
+- Parameter labelled `Voltage` but unit is ampere-turns (analogy with electrical V source).
+- Models permanent magnet or DC bias winding.
+
+## Flux Rate Meter
+
+`Lib/Magnetic/Flux Rate Meter`. Outputs dΦ/dt across two magnetic terminals. Pins: 1=p, 2=n, 3=signal out.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: fluxratemeter-probes -->
 
 | Probe signal | Description |
@@ -51,3 +83,7 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/constantmmf
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/fluxratemeter/_
 
 <!-- END VERBATIM TABLE: fluxratemeter-probes -->
+
+### Notes
+- Output Wb/s = volts per turn. Multiply by N to get winding voltage.
+- Loss-free. Inserts as zero-MMF branch.

--- a/.claude/skills/plecs-expert/references/components/magnetic.md
+++ b/.claude/skills/plecs-expert/references/components/magnetic.md
@@ -1,0 +1,53 @@
+# magnetic
+
+<!-- BEGIN VERBATIM TABLE: magneticpermeance-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Permeance | Magnetic permeance of the flux path, in webers per ampere-turn \((\mathrm{Wb/A})\) . |
+| Initial MMF | Magneto-motive force at simulation start, in ampere-turns \((\mathrm{A})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/magneticpermeance/_
+
+<!-- END VERBATIM TABLE: magneticpermeance-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: magneticpermeance-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| MMF | The magneto-motive force measured from the marked to the unmarked terminal, in ampere-turns \((\mathrm{A})\) . |
+| Flux | The magnetic flux flowing through the component, in webers \((\mathrm{Wb})\) . A flux entering at the marked terminal is counted as positive. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/magneticpermeance/_
+
+<!-- END VERBATIM TABLE: magneticpermeance-probes -->
+
+<!-- BEGIN VERBATIM TABLE: constantmmf-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Voltage | The magnitude of the MMF, in ampere-turns \((\mathrm{A})\) . The default value is 1 . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/constantmmf/_
+
+<!-- END VERBATIM TABLE: constantmmf-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: constantmmf-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| MMF | The magneto-motive force of the source, in ampere-turns \((\mathrm{A})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/constantmmf/_
+
+<!-- END VERBATIM TABLE: constantmmf-probes -->
+
+<!-- BEGIN VERBATIM TABLE: fluxratemeter-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Flux rate | The rate-of-change \(\dot{\Phi}\) of magnetic flux flowing through the component, in \((\mathrm{Wb}/\mathrm{s})\) or \(\mathrm{V}\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/fluxratemeter/_
+
+<!-- END VERBATIM TABLE: fluxratemeter-probes -->

--- a/.claude/skills/plecs-expert/references/components/system.md
+++ b/.claude/skills/plecs-expert/references/components/system.md
@@ -1,5 +1,11 @@
 # system
 
+## Subsystem
+
+`Lib/System/Subsystem`. Hierarchical container. Atomic or virtual. Atomic adds sample-time + execution boundary.
+
+Wrapped in pyplecs: no.
+
 <!-- BEGIN VERBATIM TABLE: subsystem-execution-settings -->
 
 | Name | Description |
@@ -15,6 +21,17 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/subsystem/_
 
 <!-- END VERBATIM TABLE: subsystem-execution-settings -->
 
+### Notes
+- Atomic = single execution unit. Virtual = inlined for sorting.
+- Code-gen requires atomic. Disables algebraic-loop minimization.
+- CodeGen sim mode swaps generated C in for the subsystem at run time.
+
+## Configurable Subsystem
+
+`Lib/System/Configurable Subsystem`. Subsystem with multiple internal schematics; one is selected at run time.
+
+Wrapped in pyplecs: no.
+
 <!-- BEGIN VERBATIM TABLE: conf_subsystem-parameters -->
 
 | Name | Description |
@@ -24,6 +41,16 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/subsystem/_
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/conf_subsystem/_
 
 <!-- END VERBATIM TABLE: conf_subsystem-parameters -->
+
+### Notes
+- `Configuration` variable holds 1-based index of active schematic.
+- Useful for swap-in test rigs (e.g. ideal vs lossy switch model).
+
+## Masking Subsystems
+
+`Lib/System/Masking`. Wraps a subsystem with a custom dialog, icon, and Lua-based init.
+
+Wrapped in pyplecs: no.
 
 <!-- BEGIN VERBATIM TABLE: masking-subsystems-table-0 -->
 
@@ -189,3 +216,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
 
 <!-- END VERBATIM TABLE: masking-subsystems-control-structures -->
+
+### Notes
+- Mask language is Lua. Tables = generic data structure, double-quoted strings, escape backslash.
+- Icon drawing API: `Icon:line`, `Icon:text`, `Icon:patch`, plus `IconLib.<device>` shortcuts.
+- Domain colors are name-based (`"electrical"`, `"thermal"`, etc.) — auto-adapt in dark mode.

--- a/.claude/skills/plecs-expert/references/components/system.md
+++ b/.claude/skills/plecs-expert/references/components/system.md
@@ -1,0 +1,191 @@
+# system
+
+<!-- BEGIN VERBATIM TABLE: subsystem-execution-settings -->
+
+| Name | Description |
+| --- | --- |
+| Treat as atomic unit | If this parameter is checked, PLECS treats the subsystem as atomic, otherwise as virtual (see Virtual and Atomic Subsystems ). |
+| Minimize occurrence of algebraic loops | This parameter only applies to atomic subsystems. If it is unchecked , PLECS assumes that all inputs of the subsystem have direct feedthrough , i.e. the output functions of the blocks feeding these inputs must be executed before the output function of the subsystem itself can be executed (see Block Sorting ). If the atomic subsystem is part of a feedback loop, this can result in algebraic loop errors where a virtual subsystem could be used without problems. If the parameter is checked , PLECS determines the actual feedthrough behavior of the individual inputs from the internal connectivity. A subsystem input that is internally only connected to non-direct feedthrough inputs of other blocks (e.g. the inputs of Integrator, Memory or Delay blocks) does not have direct feedthrough. This can help reduce the occurrence of algebraic loops. |
+| Sample time | A scalar specifying the sampling period or a two-element vector specifying the sampling period and offset, in seconds \((\mathrm{s})\) . This parameter is enabled only if the subsystem is atomic and specifies the sample time with which the subsystem and the components that it comprises are executed. A setting of auto (which is the default) causes the subsystem to choose its sample time based on the components that it comprises. See also section Sample Times . |
+| Enable code generation | Checking this option causes the subsystem to be added to the list of systems in the Coder Options dialog (see Generating Code ). Note that it is not possible to enable code generation for a subsystem that is contained by or that itself contains other subsystems that enable code generation. Checking this option also implicitly makes the subsystem atomic and disables the minimization of algebraic loops. |
+| Discretization step size | This parameter is enabled only if code generation is enabled. It specifies the base sample time for the generated code, in seconds \((\mathrm{s})\) , and is used to discretize the physical model equations (see Physical Model Discretization ) and continuous state variables of control blocks. |
+| Simulation mode | This parameter is enabled only if code generation is enabled. When this parameter is set to Normal , which is the default, the subsystem is simulated like a normal atomic subsystem. When the parameter is set to CodeGen , the generated code is compiled and linked to PLECS to be executed instead of the subsystem during a simulation. In connection with the “Traces” feature of the scopes (see Adding Traces ), this allows you to easily verify the fidelity of the generated code against a normal simulation. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/subsystem/_
+
+<!-- END VERBATIM TABLE: subsystem-execution-settings -->
+
+<!-- BEGIN VERBATIM TABLE: conf_subsystem-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Configuration | The name of the internal schematic that is used during simulation. The variable Configuration can be used in the mask initialization commands to check the current configuration. It contains an integer value starting at \(1\) for the first configuration. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/conf_subsystem/_
+
+<!-- END VERBATIM TABLE: conf_subsystem-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-0 -->
+
+| Property | Description |
+| --- | --- |
+| FontSize | An integer specifying the font size of the text. |
+| TextFormat | Specify the string PlainText to display the text as is (the default) or RichText to enable HTML markup such as <b></b> or <sup></sup> . |
+| Color | A string specifying the color name (preferred). All appearance-sensitive PLECS Colors are allowed. A vector { r , g , b } of three integers in the range from \(0\) to \(255\) specifying the color in RBG format. This color applies in light mode and is automatically transformed in dark mode (similar hue, inverted lightness). A table { light = { r , g , b }, dark = { r2 , g2 , b2 }} assigning custom colors in RGB format to each appearance. Note The table’s dark mode color defaults to the light mode color, such that {light = {r, g, b}} results in a fixed color for all appearances. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-0 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-1 -->
+
+| Command | Syntax |
+| --- | --- |
+| Text | text('text') text(x, y, 'text') |
+| Line | line(xvec, yvec) |
+| Patch | patch(xvec, yvec) |
+| Circle | circle(x, y, r) |
+| Color | color(r, g, b) |
+| Image | image(xvec, yvec, imread('filename')) image(xvec, yvec, imread('filename'), 'on') |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-1 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-2 -->
+
+| Color name | Light | Dark | Description |
+| --- | --- | --- | --- |
+| "text" |  |  | default text color |
+| "electrical" |  |  | electrical domain color |
+| "signal" |  |  | signal connection color |
+| "axis" |  |  | axis color for icons |
+| "thermal" |  |  | thermal domain color |
+| "thermalBg" |  |  | thermal domain background |
+| "magnetic" |  |  | magnetic domain color |
+| "magneticBg" |  |  | magnetic domain background |
+| "rotational" |  |  | rotational domain color |
+| "rotationalBg" |  |  | rotational domain background |
+| "translational" |  |  | translational domain color |
+| "translationalBg" |  |  | translational domain background |
+| "event" |  |  | event connection color |
+| "normalFg" |  |  | normal foreground |
+| "normalBg" |  |  | schematic background (configurable in dark mode) |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-2 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-3 -->
+
+| Component | Function Call |
+| --- | --- |
+| Node | IconLib.node(x0, y0) |
+| Resistor | IconLib.resistor(x0, y0, params) |
+| Capacitor | IconLib.capacitor(x0, y0, params) |
+| Inductor | IconLib.inductor(x0, y0, params) |
+| Ideal Transformer | IconLib.transformer(x0, y0, params) |
+| Diode | IconLib.diode(x0, y0, params) |
+| Thyristor | IconLib.thyristor(x0, y0, params) |
+| MOSFET | IconLib.mosfet(x0, y0, params) |
+| MOSFET with Diode | IconLib.mosfetDiode(x0, y0, params) |
+| IGBT | IconLib.igbt(x0, y0, params) |
+| IGBT with Diode | IconLib.igbtDiode(x0, y0, params) |
+| Bipolar Junction Transistor | IconLib.bjt(x0, y0, params) |
+| Junction Field Effect Transistor | IconLib.jfet(x0, y0, params) |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-3 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-4 -->
+
+| Keyword | Data Type | Description | Elements |
+| --- | --- | --- | --- |
+| rotate | Number | Specifies the rotation angle (clockwise rotation). Must be an integer multiple of 90. | all elements |
+| flip | Boolean | Flips the unrotated icon about the x-axis. | all elements |
+| wireLength | Number Table of Numbers | Specifies the additional length of the terminal wires. Can be either a number or a table of numbers (one number per terminal). The default value of 0 reproduces the standard icons used in the PLECS library browser. | all elements |
+| showArrow | Boolean | Adds an arrow decoration to indicate the direction of positive current flow. | inductor |
+| showPolarity | Boolean | Adds an annotation for the polarity of the device. | capacitor transformer |
+| polarity | String | Sets the polarity of the transformer. Available options are "+" , "-" , "+-" and "-+" . Note that the annotation is only shown if showPolarity is enabled. | transformer |
+| showCore | Boolean | Adds a magnetic core decoration. | transformer |
+| deviceType | String | Defines the transistor type. For a MOSFET or a JFET, use "n" and "p" to indicate the channel type. For a BJT, the available options are "npn" and "pnp" . By default, "n" and "npn" are assumed, respectively. | mosfet mosfetDiode bjt jfet |
+| shiftGate | Boolean | Shifts the gate terminal towards the source terminal (MOSFET, JFET) or the emitter terminal (IGBT). By default, the gate terminal is centered. | mosfet mosfetDiode igbt igbtDiode jfet |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-4 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-5 -->
+
+| Type | Description |
+| --- | --- |
+| Edit | Shows a line edit field. The entered text is interpreted as a MATLAB/Octave expression and is evaluated when a simulation is started. |
+| String | Shows a line edit field and a selector that controls whether the entered text is interpreted as a literal string or as a MATLAB/Octave expression that evaluates to a string. |
+| Combo Box | Shows a pop-up menu that allows the user to select an item from a list of possible options. Use the Combo box values editor below the parameter list to enter the list of possible options and their associated integer values that are assigned to the parameter variable. The values must be unique integers. |
+| String-Valued Combo Box | Shows a pop-up menu that allows the user to select an item from a list of possible options. Use the String-valued combo box values editor below the parameter list to enter the list of possible options and their associated string values that are assigned to the parameter variable. |
+| Thermal | Shows a thermal parameter editor that allows the user to specify a thermal description (see Thermal Description Parameter for details). If you enter a text in the Device type filter editor below the parameter list, the thermal parameter editor will show only thermal descriptions that have the matching device type. Otherwise, all thermal descriptions will be shown. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-5 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-table-6 -->
+
+| Property | Description |
+| --- | --- |
+| Value | A string specifying the parameter value |
+| Enable | A boolean (i.e. true or false ) specifying the enable state of the parameter. A disabled parameter is greyed out in the dialog and cannot be modified. |
+| Visible | A boolean (i.e. true or false ) specifying the visibility of the parameter in the dialog |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-table-6 -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-mask-icon-properties -->
+
+| Name | Description |
+| --- | --- |
+| Show subsystem frame | The subsystem frame is the rectangle that encloses the block. It is drawn if this property is set, otherwise it is hidden. |
+| Hide terminal labels | This property controls whether the terminal labels underneath the icon are shown or hidden. A terminal label is only shown if this property is unset and the name of the corresponding port block is visible. |
+| Icon rotates | If drawing commands are provided, this property determines whether the drawn icon rotates when the component is rotated. The drawn icon remains stationary if this property is unchecked. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-mask-icon-properties -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-mask-help -->
+
+| Name | Description |
+| --- | --- |
+| Remote URL | A URL of the form https://www.plexim.com is opened using the default browser of your operating system. |
+| Local HTML File | A local HTML file is specified with an absolute path (e.g. file:///C:/absolute/path/helpdoc.html ) or with a relative path (e.g. file:relative/helpdoc.html ). A relative path is resolved relative to the parent folder of the model file containing the subsystem. If the subsystem is a library link or model reference , the relative path is resolved relative to the parent folder of the source library or model file. Local HTML files are also opened using the default browser of your operating system. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-mask-help -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-types-and-variables -->
+
+| Name | Description |
+| --- | --- |
+| Nil | Nil is a type with the single value nil . It is used to represent the absence of a useful value. |
+| Booleans | The Boolean type has two values false and true . It can be used in conditional expressions. If you use other types in conditional expressions, beware that Lua considers only the Boolean false and nil as false and anything else as true. In particular, both the numerical 0 and the empty string '' or "" are considered true in conditional tests. Lua supports the logical operators and , or and not . |
+| Numbers | Lua differentiates between (double-precision) floating point numbers and (64-bit) integer numbers. Numerals with a decimal point or an exponent are considered floats; otherwise, they are treated as integers. |
+| Strings | String literals in Lua can be delimited by single or double matching quotes: local a = "a string" local b = 'another string' The difference between the two kinds is that inside one kind of quotes you can use the other kind of quote without needing to escape it. The escape character is the backslash ( \ ), and the common C escape sequences such as \n for newline are supported. Long string literals are delimited with matching double square brackets that enclose zero or more equal signs, e.g. [[...]] or [==[...]==] . They can span several lines and do not interpret escape sequences. |
+| Tables | Tables are Lua’s generic data structuring mechanism. They are used to represent e.g. arrays, sets or records. A table is essentially an associative array that accepts as keys not only numbers or strings but any other value except nil . A table is constructed with curly braces and a sequence of key/value pairs, e.g.: a = { x = 10 , y = 20 } |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-types-and-variables -->
+
+<!-- BEGIN VERBATIM TABLE: masking-subsystems-control-structures -->
+
+| Name | Description |
+| --- | --- |
+| if, then, else | The if statement tests its condition and executes the then branch if the condition is true and otherwise the else part. The condition can result in any value, but as mentioned earlier, Lua treats all values other than nil and false as true. In particular, both the numerical 0 and the empty string ( '' ) are treated as true . if Dialog : get ( 'choice' ) == '1' then Icon : text ( '+' ) else Icon : text ( '-' ) end Multiple conditions can be tested with the elseif statement. It is similar to an else followed by an if but avoids the need for and extra end : if Dialog : get ( 'choice' ) == '1' then Icon : text ( '+' ) elseif Dialog : get ( 'choice' ) == '2' then Icon : text ( '-' ) else Icon : text ( '+/-' ) end |
+| for | The for statement has the following form: for x = - 10 , 10 , 5 do Icon : line ({ x , x }, { - 10 , 10 }) end The loop variable, x , which is implicitly local to the loop, is successively assigned the values from - 10 to 10 with an increment of 5 , and for each value the loop body is executed. The result of the example will be five parallel vertical lines. The step value is optional; if it is omitted, Lua will assume a step value of 1 . |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/_
+
+<!-- END VERBATIM TABLE: masking-subsystems-control-structures -->

--- a/.claude/skills/plecs-expert/references/components/thermal.md
+++ b/.claude/skills/plecs-expert/references/components/thermal.md
@@ -1,5 +1,13 @@
 # thermal
 
+## Heat Sink
+
+`Lib/Thermal/Heat Sink`. Frame element. Encloses semiconductors so loss probes can inject heat into a thermal network. Pins: variable thermal terminals (configurable).
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: heatsink-parameters -->
 
 | Name | Description |
@@ -23,6 +31,19 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/heatsink/_
 
 <!-- END VERBATIM TABLE: heatsink-probes -->
 
+### Notes
+- Heat sink is a graphical frame. Drag around devices to enclose them.
+- Capacitance 0 → must connect external thermal cap or ambient temperature.
+- Width must match enclosed device width when vectorized.
+
+## Thermal Capacitor
+
+`Lib/Thermal/Thermal Capacitor`. Stores heat. Thermal-domain analog of electrical capacitor. Pins: 1=p (marked +), 2=n.
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: thermalcapacitor-parameters -->
 
 | Name | Description |
@@ -44,6 +65,18 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/thermalcapa
 
 <!-- END VERBATIM TABLE: thermalcapacitor-probes -->
 
+### Notes
+- Units J/K. Sign convention: + terminal is hotter side.
+- Pair with thermal resistor blocks to build Foster/Cauer networks.
+
+## Ambient Temperature
+
+`Lib/Thermal/Ambient Temperature`. Fixed-temperature thermal source. Pins: 1=thermal terminal, 2=signal in (when external).
+
+Wrapped in pyplecs: no.
+
+SPICE map: n/a (no SPICE equivalent).
+
 <!-- BEGIN VERBATIM TABLE: ambienttemperature-parameters -->
 
 | Name | Description |
@@ -53,3 +86,7 @@ _Source: https://docs.plexim.com/plecs/latest/components-by-category/thermalcapa
 _Source: https://docs.plexim.com/plecs/latest/components-by-category/ambienttemperature/_
 
 <!-- END VERBATIM TABLE: ambienttemperature-parameters -->
+
+### Notes
+- Thermal-domain analog of an electrical voltage source.
+- Default: scalar heat sink absorbs all elements of vector inner connection.

--- a/.claude/skills/plecs-expert/references/components/thermal.md
+++ b/.claude/skills/plecs-expert/references/components/thermal.md
@@ -1,0 +1,55 @@
+# thermal
+
+<!-- BEGIN VERBATIM TABLE: heatsink-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Number of terminals | This parameter allows you to change the number of external thermal connectors of a heat sink. The default is 0 . |
+| Thermal capacitance | The value of the internal thermal capacitance, in \((\mathrm{J}/\mathrm{K})\) . The default is 0 . If the capacitance is set to zero, the heat sink must be connected to an external thermal capacitance or to a fixed temperature. |
+| Initial temperature | The initial temperature difference between the heat sink and the thermal reference at simulation start, in degrees Celsius \((^\circ\mathrm{C})\) . If left blank or if the value is nan , PLECS will initialize the value based on a thermal “DC” analysis, see Temperature Initialization . |
+| Width | This parameter allows you to set the width of the internal thermal capacitance and the external terminals. The default is 1 . A non-scalar heat sink can enclose only components that have the same width. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/heatsink/_
+
+<!-- END VERBATIM TABLE: heatsink-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: heatsink-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Temperature | The temperature difference between the heat sink and the thermal reference, in degrees Celsius \((^\circ\mathrm{C})\) . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/heatsink/_
+
+<!-- END VERBATIM TABLE: heatsink-probes -->
+
+<!-- BEGIN VERBATIM TABLE: thermalcapacitor-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Capacitance | The value of the capacitor, in \((\mathrm{J/K})\) . All finite positive and negative values are accepted, including 0 . The default is 1 . |
+| Initial temperature | The initial temperature difference between the thermal ports or between the thermal port and thermal reference at simulation start, in degrees Celsius \((^\circ\mathrm{C})\) . If left blank or if the value is nan , PLECS will initialize the value based on a thermal DC analysis, see Temperature Initialization . |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/thermalcapacitor/_
+
+<!-- END VERBATIM TABLE: thermalcapacitor-parameters -->
+
+<!-- BEGIN VERBATIM TABLE: thermalcapacitor-probes -->
+
+| Probe signal | Description |
+| --- | --- |
+| Temperature | The temperature difference measured across the capacitance, in degrees Celsius \((^\circ\mathrm{C})\) . A positive value is measured when the temperature at the terminal marked with “+” is greater than the temperature at the unmarked terminal. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/thermalcapacitor/_
+
+<!-- END VERBATIM TABLE: thermalcapacitor-probes -->
+
+<!-- BEGIN VERBATIM TABLE: ambienttemperature-parameters -->
+
+| Name | Description |
+| --- | --- |
+| Allow vector connection to scalar heat sink | This parameter is only relevant if the block has a non-scalar inner connection. When the parameter is set to on , the enclosing heat sink must also be non-scalar and have a matching width. When the parameter is set to off (the default), the enclosing heat sink may also be scalar, and all elements of the inner connection will be connected to the single heat sink element. |
+
+_Source: https://docs.plexim.com/plecs/latest/components-by-category/ambienttemperature/_
+
+<!-- END VERBATIM TABLE: ambienttemperature-parameters -->

--- a/.claude/skills/plecs-expert/references/cscript.md
+++ b/.claude/skills/plecs-expert/references/cscript.md
@@ -1,5 +1,13 @@
 # cscript
 
+C-Script block. User-supplied C code runs at each major time step. Useful for custom logic, lookup tables, foreign-function calls. Pins: configurable input/output terminals.
+
+Wrapped in pyplecs: no.
+
+## Macro reference
+
+The PLECS C-Script API exposes these macros to the user code. R = read-only, W = write-only, R/W = read-write.
+
 <!-- BEGIN VERBATIM TABLE: c-scripts-table-0 -->
 
 | Macro | Type | Access | Description |
@@ -37,3 +45,10 @@
 _Source: https://docs.plexim.com/plecs/latest/c-scripts/_
 
 <!-- END VERBATIM TABLE: c-scripts-table-0 -->
+
+### Notes
+- `OutputSignal` writes are only valid inside the output function call. Other phases see them as read-only.
+- `ContState` / `DiscState` cannot change during minor time steps. Update only in `update` function.
+- `SetErrorMessage` aborts at end of step. Pair with `return` to skip the rest of the step.
+- Error / warning string pointers must point to static memory. Don't pass stack buffers.
+- For non-trivial logic prefer C-Script over masking-Lua: faster, debugger-friendly, type-checked.

--- a/.claude/skills/plecs-expert/references/cscript.md
+++ b/.claude/skills/plecs-expert/references/cscript.md
@@ -1,0 +1,39 @@
+# cscript
+
+<!-- BEGIN VERBATIM TABLE: c-scripts-table-0 -->
+
+| Macro | Type | Access | Description |
+| --- | --- | --- | --- |
+| NumInputTerminals | int | R | Returns the number of input terminals. |
+| NumOutputTerminals | int | R | Returns the number of output terminals. |
+| NumInputSignals ( int i ) | int | R | Returns the number of elements (i.e. the width) of the signal connected to the i th input terminal. |
+| NumOutputSignals ( int i ) | int | R | Returns the number of elements (i.e. the width) of the signal connected to the i th output terminal. |
+| NumContStates | int | R | Returns the number of continuous states. |
+| NumDiscStates | int | R | Returns the number of discrete states. |
+| NumZCSignals | int | R | Returns the number of zero-crossing signals. |
+| NumParameters | int | R | Returns the number of user parameters. |
+| CurrentTime | double | R | Returns the current simulation time (resp. the simulation start time during the start function call). |
+| NumSampleTime | int | R | Returns the number of sample times. |
+| SampleTimePeriod ( int i ) | int | R | Returns the period of the i th sample time. |
+| SampleTimeOffset ( int i ) | int | R | Returns the offset of the i th sample time. |
+| IsMajorStep | int | R | Returns 1 during major time steps, else 0 . |
+| IsSampleHit ( int i ) | int | R | Returns 1 if the i th sample time currently has a hit, else 0 . |
+| NextSampleHit | double | R/W | Specifies the next simulation time when the block should be executed. This is relevant only for blocks that have registered a discrete-variable sample time. |
+| InputSignal ( int i , int j ) | double | R | Returns the value of the j th element of the i th input signal terminal. See the C-Script block for information on how to increase the default number of input signal terminals. |
+| OutputSignal ( int i , int j ) | double | R/W | Provides access to the value of the j th element of the i th output signal terminal. See the C-Script block for information on how to increase the default number of output signal terminals. Output signals may only be changed during the output function call. |
+| ContState ( int i ) | double | R/W | Provides access to the value of the i th continuous state. Continuous state variables may not be changed during minor time steps. |
+| ContDeriv ( int i ) | double | R/W | Provides access to the derivative of the i th continuous state. |
+| DiscState ( int i ) | double | R/W | Provides access to the value of the i th discrete state. Discrete state variables may not be changed during minor time steps. |
+| ZCSignal ( int i ) | double | R/W | Provides access to the i th zero-crossing signal. |
+| ParamNumDims ( int i ) | int | R | Returns the number of dimensions of the i th user parameter. |
+| ParamDim ( int i , int j ) | int | R | Returns the j th dimension of the i th user parameter. |
+| ParamRealData ( int i , int j ) | double | R | Returns the value of the j th element of the i th user parameter. The index j is a linear index into the parameter elements. Indices into multi-dimensional arrays must be calculated using the information provided by the ParamNumDims and ParamDim macros. If the parameter is a string, this macro will produce a runtime error or an access violation if runtime checks are disabled. |
+| ParamStringData ( int i ) | char* | R | Returns a pointer to a UTF-8 encoded, null-terminated C string that represents the i th user parameter. If the parameter is not a string, this macro will produce a runtime error or returns NULL if runtime checks are disabled. |
+| WriteCustomStateDouble ( double val ) WriteCustomStateInt ( int val ) WriteCustomStateData ( void * data , int len ) | void void void | W | Write a custom state of type double, int or custom data with len number of bytes. Use multiple calls for multiple values. |
+| ReadCustomStateDouble () ReadCustomStateInt () ReadCustomStateData ( void * data , int len ) | double int void | R | Read a custom state of type double, int or custom data with len number of bytes. Use multiple calls for multiple values. |
+| SetErrorMessage ( char * msg ) | void | W | Use this macro to report errors that occur in your code. The simulation will be terminated after the current simulation step. In general, this macro should be followed by a return statement. The pointer msg must point to static memory. |
+| SetWarningMessage ( char * msg ) | void | W | Use this macro to report warnings. The warning status is reset as soon as the current C-Script function returns, so you do not need to reset it manually. The pointer msg must point to static memory. |
+
+_Source: https://docs.plexim.com/plecs/latest/c-scripts/_
+
+<!-- END VERBATIM TABLE: c-scripts-table-0 -->

--- a/.claude/skills/plecs-expert/references/plecs-xml-grammar.md
+++ b/.claude/skills/plecs-expert/references/plecs-xml-grammar.md
@@ -1,0 +1,9 @@
+# `.plecs` XML Grammar
+
+Hand-authored from `data/*.plecs` samples in this repo. PLECS publishes no public XML grammar page on docs.plexim.com.
+
+<!-- BEGIN VERBATIM TABLE: plecs-xml-grammar -->
+
+(Populated in Task 15 — see `docs/superpowers/plans/2026-04-27-plecs-expert-skill.md`. Will hold the minimum-viable XML element table extracted from `data/simple_buck_prb.plecs.bak` and similar samples.)
+
+<!-- END VERBATIM TABLE: plecs-xml-grammar -->

--- a/.claude/skills/plecs-expert/references/plecs-xml-grammar.md
+++ b/.claude/skills/plecs-expert/references/plecs-xml-grammar.md
@@ -2,8 +2,115 @@
 
 Hand-authored from `data/*.plecs` samples in this repo. PLECS publishes no public XML grammar page on docs.plexim.com.
 
+PLECS files are not XML. Format is Tcl-ish curly-brace key-value text. Keys followed by atom or quoted string. Sub-blocks open with `Name {` and close with `}`. Multi-line strings continue on the next line by closing the quote and reopening it. Comments do not appear in saved files.
+
+Top-level outer block: `Plecs { ... }`. Inside it: scalar settings, then `Terminal { ... }` (zero or more), then `Schematic { ... }`. The `Schematic` block holds `Component { ... }` and `Connection { ... }` children.
+
+## Top-level grammar (extracted from `data/simple_buck_prb.plecs.bak`)
+
 <!-- BEGIN VERBATIM TABLE: plecs-xml-grammar -->
 
-(Populated in Task 15 — see `docs/superpowers/plans/2026-04-27-plecs-expert-skill.md`. Will hold the minimum-viable XML element table extracted from `data/simple_buck_prb.plecs.bak` and similar samples.)
+| Element | Parent | Cardinality | Children / Notes |
+| --- | --- | --- | --- |
+| `Plecs { }` | (file root) | 1 | Outer container. Holds model name, version, solver settings, code-gen settings, init code, then `Terminal` and `Schematic`. |
+| `Name "<str>"` | `Plecs` | 1 | Model name. |
+| `Version "<str>"` | `Plecs` | 1 | PLECS version that wrote the file. Example: `"4.7"`. |
+| `CircuitModel "<str>"` | `Plecs` | 1 | Either `"ContStateSpace"` or `"DiscStateSpace"`. |
+| `StartTime "<expr>"` | `Plecs` | 1 | Solver start time. String holding a MATLAB/Octave expression. |
+| `TimeSpan "<expr>"` | `Plecs` | 1 | Solver run length. |
+| `Solver "<str>"` | `Plecs` | 1 | One of `auto`, `dopri`, `radau`, `discrete`. |
+| `MaxStep`, `InitStep`, `FixedStep`, `Refine`, `ZCStepSize`, `RelTol`, `AbsTol` | `Plecs` | 1 each | Solver tuning knobs. Strings holding numbers. |
+| `TurnOnThreshold "<expr>"` | `Plecs` | 1 | Diode turn-on threshold. |
+| `InitializationCommands "<str>"` | `Plecs` | 1 | Multi-line MATLAB/Octave init code. Lines wrap by closing+reopening quotes. |
+| `InitialState`, `SystemState` | `Plecs` | 1 each | Initial-condition selector + stored state struct. |
+| `TaskingMode`, `TaskConfigurations` | `Plecs` | 1 each | Code-gen tasking config. |
+| `CodeGen*` keys | `Plecs` | 0..N | All code-gen options (`CodeGenTarget`, `CodeGenBaseName`, `CodeGenOutputDir`, `CodeGenParameterInlining`, etc.). |
+| `Terminal { ... }` | `Plecs` | 0..N | Sub-block. Holds `Type Output` or `Type Input` and `Index "<int>"`. |
+| `Schematic { ... }` | `Plecs` | 1 | Holds the model graph: `Location`, `ZoomFactor`, then `Component` and `Connection` children. |
+| `Component { ... }` | `Schematic` | 0..N | One block per component instance. See child grammar below. |
+| `Connection { ... }` | `Schematic` | 0..N | One per wire. See child grammar below. |
+| `Type <atom>` | `Component` | 1 | Library type name. Examples: `Resistor`, `Inductor`, `Capacitor`, `Diode`, `Mosfet`, `DCVoltageSource`, `PulseGenerator`, `Scope`, `PlecsProbe`, `Output`, `Display`, `Constant`. |
+| `Name "<str>"` | `Component` | 1 | Instance name. Newlines allowed via `\n`. |
+| `Show <on\|off>` | `Component` | 1 | Whether name label is visible. |
+| `Position [x, y]` | `Component` | 1 | Schematic placement. |
+| `Direction <up\|down\|left\|right>` | `Component` | 1 | Rotation. |
+| `Flipped <on\|off>` | `Component` | 1 | Mirror flag. |
+| `LabelPosition <atom>` | `Component` | 1 | One of `north`, `south`, `east`, `west`, `northeast`, `southeast`, etc. |
+| `Frame [x1, y1; x2, y2]` | `Component` | 0..1 | Bounding box for masked / textual blocks. |
+| `Parameter { Variable "<name>" Value "<expr>" Show <on\|off> }` | `Component` | 0..N | One entry per editable parameter. `Variable` matches the docs name; `Value` is a MATLAB/Octave expression. |
+| `Probe { Component "<inst>" Path "<str>" Signals { "<sig>", ... } }` | `Component` of Type `PlecsProbe` | 0..N | Per measured signal entry. |
+| `Type Wire` | `Connection` | 1 | Always `Wire` for electrical/signal connections. |
+| `SrcComponent "<inst>"`, `SrcTerminal <n>` | `Connection` | 1 each | Source block + terminal index. |
+| `DstComponent "<inst>"`, `DstTerminal <n>` | `Connection` | 0..1 each | Destination block + terminal index. Absent when wire ends in a junction. |
+| `Points [x1, y1; x2, y2; ...]` | `Connection` | 0..1 | Polyline waypoints in schematic coords. |
+| `Branch { ... }` | `Connection` | 0..N | T-junction child wire. Same fields as `Connection`. |
+
+_Source: hand-extracted from `data/simple_buck_prb.plecs.bak`, `data/cuk.plecs`, `data/B6_diode.plecs`._
 
 <!-- END VERBATIM TABLE: plecs-xml-grammar -->
+
+## MVE — minimum viable buck excerpt
+
+Trimmed from `data/simple_buck_prb.plecs.bak`. Shows top-level scalars, one `Component`, one `Connection`.
+
+```
+Plecs {
+  Name          "simple_buck_prb"
+  Version       "4.7"
+  CircuitModel  "ContStateSpace"
+  StartTime     "0.0"
+  TimeSpan      "T_sim"
+  Solver        "radau"
+  MaxStep       "1e-6"
+  InitializationCommands "T_sim = 1e-3;\nVi = 24;\nVo_ref = 12;\n"
+  Schematic {
+    Location      [915, 288; 1725, 613]
+    ZoomFactor    1
+    Component {
+      Type          DCVoltageSource
+      Name          "VDCin"
+      Show          on
+      Position      [85, 95]
+      Direction     up
+      Flipped       off
+      LabelPosition west
+      Parameter {
+        Variable      "V"
+        Value         "Vi"
+        Show          off
+      }
+    }
+    Component {
+      Type          Resistor
+      Name          "R1"
+      Show          on
+      Position      [370, 100]
+      Direction     up
+      Flipped       off
+      LabelPosition east
+      Parameter {
+        Variable      "R"
+        Value         "Ro"
+        Show          off
+      }
+    }
+    Connection {
+      Type          Wire
+      SrcComponent  "VDCin"
+      SrcTerminal   1
+      Points        [85, 60]
+      DstComponent  "R1"
+      DstTerminal   1
+    }
+  }
+}
+```
+
+### Notes
+
+- File is plain ASCII. Editable by hand. CRLF line endings on Windows save.
+- Boolean atoms: `on` / `off` (component flags), or strings like `"1"` / `"0"` (numeric flags).
+- Multi-line strings split with `"...continue\n"` followed by `"...next line"` on next physical row.
+- Component `Type` strings match the underlying PLECS class name, not the dialog title (e.g. `Mosfet`, not `MOSFET`).
+- Terminal indices in `Connection` start at 1.
+- For converter use cases the round-trip parser only needs to handle: `Plecs`, `Schematic`, `Component`, `Connection`, `Parameter`, `Probe`, `Branch`, `Terminal`. Other top-level keys are scalar and can pass through verbatim.

--- a/.claude/skills/plecs-expert/references/rpc-api.md
+++ b/.claude/skills/plecs-expert/references/rpc-api.md
@@ -1,5 +1,11 @@
 # rpc-api
 
+PLECS exposes an XML-RPC interface on `localhost:1080` (default). pyplecs wraps a curated subset via `pyplecs.PlecsServer`. Methods on that wrapper: `close`, `health_check`, `is_available`, `load_modelvars`, `run_sim_with_datastream`, `run_sim_with_mat_file`, `set_value`, `simulate`, `simulate_batch`, `simulate_raw`. Anything else use `plecs_rpc(...)` for live introspection.
+
+## Scope export — bitmap options
+
+Field bag passed to `plecs.scope.SaveAsImage` and similar. Not wrapped — call via `plecs_rpc('plecs.scope.SaveAsImage', ...)`.
+
 <!-- BEGIN VERBATIM TABLE: scripting-table-0 -->
 
 | Name | Description |
@@ -20,6 +26,10 @@
 _Source: https://docs.plexim.com/plecs/latest/scripting/_
 
 <!-- END VERBATIM TABLE: scripting-table-0 -->
+
+## SolverOpts — simulate / simulate_raw
+
+`SolverOpts` overrides solver settings for one simulation run. Wrapped via `pyplecs.PlecsServer.simulate` and `simulate_raw` — pass dict as `solver_opts=` kwarg.
 
 <!-- BEGIN VERBATIM TABLE: scripting-table-1 -->
 
@@ -43,6 +53,10 @@ _Source: https://docs.plexim.com/plecs/latest/scripting/_
 
 <!-- END VERBATIM TABLE: scripting-table-1 -->
 
+## OutputTimesOption — output-time mode
+
+Controls how `OutputTimes` is interpreted by the scripted simulator. Use via `solver_opts={'OutputTimes': [...], 'OutputTimesOption': 'specified'}`.
+
 <!-- BEGIN VERBATIM TABLE: scripting-table-2 -->
 
 | OutputTimesOption | Interpretation of OutputTimes |
@@ -54,6 +68,10 @@ _Source: https://docs.plexim.com/plecs/latest/scripting/_
 _Source: https://docs.plexim.com/plecs/latest/scripting/_
 
 <!-- END VERBATIM TABLE: scripting-table-2 -->
+
+## AnalysisOpts — steady-state and small-signal
+
+Field bag for `plecs.analyze(...)`. Not wrapped — call via `plecs_rpc('plecs.analyze', mdl, name, opts)`.
 
 <!-- BEGIN VERBATIM TABLE: scripting-table-3 -->
 
@@ -82,12 +100,16 @@ _Source: https://docs.plexim.com/plecs/latest/scripting/_
 
 <!-- END VERBATIM TABLE: scripting-table-3 -->
 
+## OutputFormat / ModelVars / SolverOpts — top-level options struct
+
+Top-level dict given to `plecs.simulate(mdl, opts)` or `plecs.analyze(mdl, name, opts)`. `ModelVars` is wrapped via `pyplecs.PlecsServer.load_modelvars` (loads a `.m` file) and via `set_value` (per-parameter). `SolverOpts` is wrapped via `simulate` / `simulate_raw`. `OutputFormat` controls return shape; pyplecs wrappers select the right value.
+
 <!-- BEGIN VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options -->
 
 | Name | Description |
 | --- | --- |
 | OutputFormat | The optional field OutputFormat is a string that lets you choose whether the results of a simulation or analysis should be returned as a RPC struct ( Plain ) or in binary form using the MAT-file format ( MatFile ). The binary format is much more efficient if the result contains many data points, but the client may not be able to interpret it, so the default is Plain . |
-| ModelVars | The optional field ModelVars is a struct variable that allows you to override variable values defined by the model initialization commands. Each field name is treated as a variable name; the field value is assigned to the corresponding variable. Values can be numerical scalars, vectors, matrices or 3d arrays or strings. The override values are applied after the model initialization commands have been evaluated and before the component parameters are evaluated as shown in Fig. 117 . Fig. 117 Execution order for Simulation Scripts (left) and RPC (right)  |
+| ModelVars | The optional field ModelVars is a struct variable that allows you to override variable values defined by the model initialization commands. Each field name is treated as a variable name; the field value is assigned to the corresponding variable. Values can be numerical scalars, vectors, matrices or 3d arrays or strings. The override values are applied after the model initialization commands have been evaluated and before the component parameters are evaluated as shown in Fig. 117 . Fig. 117 Execution order for Simulation Scripts (left) and RPC (right)  |
 | SolverOpts | The optional field SolverOpts is a struct variable that allows you to override the solver settings specified in the Simulation Parameters dialog. Each field name is treated as a solver parameter name; the field value is assigned to the corresponding solver parameter. Tab. 18 lists the possible parameters. |
 
 _Source: https://docs.plexim.com/plecs/latest/scripting/_
@@ -103,3 +125,8 @@ _Source: https://docs.plexim.com/plecs/latest/scripting/_
 _Source: https://docs.plexim.com/plecs/latest/scripting/_
 
 <!-- END VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options-2 -->
+
+### Notes
+- pyplecs targets the simulation path. Steady-state and small-signal analysis are not wrapped — call via `plecs_rpc('plecs.analyze', mdl, name, opts)`.
+- `MatFile` mode returns binary; `simulate_raw` covers it. `Plain` returns dict; `simulate` covers it.
+- Variable overrides via `ModelVars` apply after init commands and before component param evaluation.

--- a/.claude/skills/plecs-expert/references/rpc-api.md
+++ b/.claude/skills/plecs-expert/references/rpc-api.md
@@ -1,0 +1,105 @@
+# rpc-api
+
+<!-- BEGIN VERBATIM TABLE: scripting-table-0 -->
+
+| Name | Description |
+| --- | --- |
+| Size | A two-element integer vector specifying the width and height of the bitmap in pixels. |
+| Resolution | An integer specifying the resolution of the bitmap in pixels per inch. |
+| TimeRange | A two-element real vector specifying the time range of the data to be shown. |
+| XLim | A two-element real vector specifying the limits of the x-axis. For a normal scope this is equivalent to TimeRange . |
+| YLim | A cell array containing two-element real vectors specifying the limits of the y-axis of the plot(s). For a scope with a single plot a vector may be given directly. |
+| XLabel | A string specifying the x-axis label. |
+| YLabel | A cell array containing strings specifying the y-axis labels of the plot(s). For a scope with a single plot a string may be given directly. |
+| Title | A cell array containing strings specifying the title of the plot(s). For a scope with a single plot a string may be given directly. |
+| LegendPosition | A string specifying the legend position. Possible values are none , topleft , topmiddle , topright , bottomleft , bottommiddle and bottomright . |
+| Font | A string specifying the font name to be used for the labels and the legend. |
+| LabelFontSize | An integer specifying the label font size in points. |
+| LegendFontSize | An integer specifying the legend font size in points. |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-table-0 -->
+
+<!-- BEGIN VERBATIM TABLE: scripting-table-1 -->
+
+| Parameter | Description |
+| --- | --- |
+| Solver | The solver to use for the simulation. Possible values are auto , dopri , radau and discrete (see PLECS Standalone Parameters ). |
+| StartTime | The start time specifies the initial value of the simulation time variable \(t\) at the beginning of a simulation, in seconds \((\mathrm{s})\) . |
+| TimeSpan | The simulation ends when the simulation time has advanced by the specified time span. |
+| StopTime | This option is obsolete. It is provided to keep old scripts working. We strongly advise against using it in new code. |
+| OutputTimes OutputTimesOption | These options control the simulation times that are included in the result of a scripted simulation. See the table below. |
+| InitialSystemState | Specifies the initial system state used for the simulation. This will override the System State setting in the simulation parameters (see System State ). The system state struct can be retrieved after the completion of a simulation or steady-state analysis using the command plecs ( 'get' , mdlName , 'SystemState' ) |
+| Timeout | A non-negative number that specifies the maximum number of seconds (wall-clock time) that a simulation or analysis is allowed to run. After this period the simulation or analysis is stopped with a timeout error. A value of 0 disables the timeout. |
+| MaxStep | See the description for Max Step Size in section PLECS Standalone Parameters . This parameter is only evaluated for variable step solvers. |
+| InitStep | See the description for Initial Step Size in section PLECS Standalone Parameters . This parameter is only evaluated for variable step solvers. |
+| FixedStep | This option specifies the fixed time increments for the solver and also the sample time used for the state-space discretization of the physical model. It is only evaluated for the fixed step solver. |
+| AbsTol | See the description for Tolerances in section PLECS Standalone Parameters . |
+| RelTol | See the description for Tolerances in section PLECS Standalone Parameters . |
+| Refine | See parameter Refine factor in section PLECS Standalone Parameters . |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-table-1 -->
+
+<!-- BEGIN VERBATIM TABLE: scripting-table-2 -->
+
+| OutputTimesOption | Interpretation of OutputTimes |
+| --- | --- |
+| specified | The simulation result contains only the simulation times specified in the OutputTimes vector. This is also the default behavior if only the vector OutputTimes is provided and OutputTimesOption is omitted. |
+| additional | The simulation result contains the simulation times specified in the OutputTimes vector in addition to all simulation steps that the solver makes. |
+| range | The simulation result contains all simulation steps that the solver makes within the time span from OutputTimes(1) to OutputTimes(end) . If the vector OutputTimes contains more than two values, the additional simulation times are also included in the result. |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-table-2 -->
+
+<!-- BEGIN VERBATIM TABLE: scripting-table-3 -->
+
+| Parameter | Description |
+| --- | --- |
+| TimeSpan | System period length; this is the least common multiple of the periods of independent sources in the system. |
+| StartTime | Simulation start time. |
+| Tolerance | Relative error tolerance used in the convergence criterion of a steady-state analysis. |
+| MaxIter | Maximum number of iterations allowed in a steady-state analysis. |
+| JacobianPerturbation | Relative perturbation of the state variables used to calculate the approximate Jacobian matrix. |
+| JacobianCalculation | Controls the way the Jacobian matrix is calculated ( full , fast ). The default is fast . |
+| InitCycles | Number of cycle-by-cycle simulations that should be performed before the actual analysis. This parameter can be used to provide the initial steady-state analysis with a better starting point. |
+| ShowCycles | Number of steady-state cycles that should be simulated at the end of an analysis. This parameter is evaluated only for a steady-state analysis. |
+| FrequencyRange | Range of the perturbation frequencies. This parameter is evaluated only for a small-signal analysis. |
+| FrequencyScale | Specifies whether the sweep frequencies should be distributed on a linear or logarithmic scale. This parameter is evaluated only for a small-signal analysis. |
+| AdditionalFreqs | A vector specifying frequencies to be swept in addition to the automatically distributed frequencies. This parameter is evaluated only for a small-signal analysis. |
+| NumPoints | The number of automatically distributed perturbation frequencies. This parameter is evaluated only for a small-signal analysis. |
+| Perturbation | The full block path (excluding the model name) of the Small Signal Perturbation block that will be active during an analysis. This parameter is evaluated only for a small-signal analysis. |
+| Response | The full block path (excluding the model name) of the Small Signal Response block that will record the system response during an analysis. This parameter is evaluated only for a small-signal analysis. |
+| AmplitudeRange | The amplitude range of the sinusoidal perturbation signals for an ac sweep. This parameter is evaluated only for an ac sweep. |
+| Amplitude | The amplitude of the discrete pulse perturbation for an impulse response analysis. This parameter is evaluated only for an impulse response analysis. |
+| MaxNumberOfThreads | The maximum number of parallel threads that may be used during the analysis. |
+| ShowResults | Specifies whether to show a Bode plot after a small-signal analysis. This parameter is evaluated only for a small-signal analysis. |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-table-3 -->
+
+<!-- BEGIN VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options -->
+
+| Name | Description |
+| --- | --- |
+| OutputFormat | The optional field OutputFormat is a string that lets you choose whether the results of a simulation or analysis should be returned as a RPC struct ( Plain ) or in binary form using the MAT-file format ( MatFile ). The binary format is much more efficient if the result contains many data points, but the client may not be able to interpret it, so the default is Plain . |
+| ModelVars | The optional field ModelVars is a struct variable that allows you to override variable values defined by the model initialization commands. Each field name is treated as a variable name; the field value is assigned to the corresponding variable. Values can be numerical scalars, vectors, matrices or 3d arrays or strings. The override values are applied after the model initialization commands have been evaluated and before the component parameters are evaluated as shown in Fig. 117 . Fig. 117 Execution order for Simulation Scripts (left) and RPC (right)  |
+| SolverOpts | The optional field SolverOpts is a struct variable that allows you to override the solver settings specified in the Simulation Parameters dialog. Each field name is treated as a solver parameter name; the field value is assigned to the corresponding solver parameter. Tab. 18 lists the possible parameters. |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options -->
+
+<!-- BEGIN VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options-2 -->
+
+| Name | Description |
+| --- | --- |
+| AnalysisOpts | For an analysis the optional field AnalysisOpts is a struct variable that allows you to override the analysis settings defined in the Analysis Tools dialog. Each field name is treated as an analysis parameter name, the field value is assigned to the corresponding analysis parameter. The following tables list the possible parameters: |
+
+_Source: https://docs.plexim.com/plecs/latest/scripting/_
+
+<!-- END VERBATIM TABLE: scripting-scripted-simulation-and-analysis-options-2 -->

--- a/.claude/skills/plecs-expert/references/solver.md
+++ b/.claude/skills/plecs-expert/references/solver.md
@@ -1,5 +1,11 @@
 # solver
 
+Solver settings live in the model's Simulation Parameters dialog. Override per run via the `SolverOpts` field; see [rpc-api.md](rpc-api.md). Wrapped via `pyplecs.PlecsServer.simulate` and `simulate_raw` — pass `solver_opts={'Solver': 'radau', ...}` etc.
+
+## Simulation Time
+
+Top-level run window. `StartTime` and `TimeSpan` are also exposed in `SolverOpts`.
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-simulation-time -->
 
 | Name | Description |
@@ -11,6 +17,13 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-simulation-time -->
 
+### Notes
+- `StartTime` ignored when running from a stored system state.
+
+## Solver — variable-step
+
+Two variable-step methods: DOPRI (non-stiff, default) and RADAU (stiff). `auto` picks DOPRI then switches to RADAU on stiffness detection.
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-solver -->
 
 | Name | Description |
@@ -21,6 +34,10 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-solver -->
 
+## Solver — fixed-step
+
+Fixed-step `discrete` solver. Used for real-time simulation and code-gen. Forward Euler for non-state-space dynamics.
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-solver-2 -->
 
 | Name | Description |
@@ -30,6 +47,10 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-solver-2 -->
+
+## Variable-step solver options
+
+Tuning knobs for DOPRI / RADAU. Defaults are usable; tighten `RelTol` and `AbsTol` if curves look noisy.
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-variable-step-solver-options -->
 
@@ -45,6 +66,12 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-variable-step-solver-options -->
 
+### Notes
+- `Refine factor` >1 cheaper than reducing `MaxStep` for smoother plots.
+- `analytical` Jacobian preferred over `finite differences` for RADAU.
+
+## Fixed-step options
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-fixed-step-solver-options -->
 
 | Name | Description |
@@ -55,6 +82,10 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-fixed-step-solver-options -->
 
+## Circuit model — diode threshold
+
+Globally controls turn-on detection for line-commutated devices.
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-circuit-model-options -->
 
 | Name | Description |
@@ -64,6 +95,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-circuit-model-options -->
+
+## Circuit model — discretization and switch behavior
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-circuit-model-options-2 -->
 
@@ -78,6 +111,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-circuit-model-options-2 -->
 
+## Sample times
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-sample-times -->
 
 | Name | Description |
@@ -88,6 +123,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-sample-times -->
+
+## State-space calculation
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-state-space-calculation -->
 
@@ -102,6 +139,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-state-space-calculation -->
 
+## Data types
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-data-types -->
 
 | Name | Description |
@@ -111,6 +150,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-data-types -->
+
+## Assertions
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-assertions -->
 
@@ -122,6 +163,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-assertions -->
 
+## Algebraic loops
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-algebraic-loops -->
 
 | Name | Description |
@@ -132,6 +175,10 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-algebraic-loops -->
+
+## Diagnostics
+
+Severity controls per failure mode. Default action: `error` for most.
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-diagnostics -->
 
@@ -150,6 +197,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-diagnostics -->
 
+## System State
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-system-state -->
 
 | Name | Description |
@@ -162,6 +211,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-system-state -->
 
+## Diode Turn-On Threshold and Type (Blockset variant)
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-id1 -->
 
 | Name | Description |
@@ -172,6 +223,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-id1 -->
+
+## Discrete state-space options (Blockset)
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-discrete-state-space-options -->
 
@@ -186,6 +239,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-discrete-state-space-options -->
+
+## Diagnostics (Blockset variant)
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-id2 -->
 
@@ -206,6 +261,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-id2 -->
 
+## Sample times (Blockset variant)
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-id3 -->
 
 | Name | Description |
@@ -217,6 +274,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-id3 -->
 
+## Algebraic loops (Blockset variant)
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-id4 -->
 
 | Name | Description |
@@ -227,6 +286,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-id4 -->
+
+## State-space calculation (Blockset variant)
 
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-id5 -->
 
@@ -241,6 +302,8 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 
 <!-- END VERBATIM TABLE: simulation-parameters-id5 -->
 
+## Simulink Coder integration (Blockset)
+
 <!-- BEGIN VERBATIM TABLE: simulation-parameters-simulink-coder -->
 
 | Name | Description |
@@ -251,3 +314,7 @@ _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/
 _Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
 
 <!-- END VERBATIM TABLE: simulation-parameters-simulink-coder -->
+
+### Notes
+- "Blockset variant" tables (id1..id5) duplicate fields from PLECS Standalone with Simulink-specific names. Treat them as the same knobs.
+- For pyplecs (Standalone XML-RPC) only the non-Blockset tables apply at run time.

--- a/.claude/skills/plecs-expert/references/solver.md
+++ b/.claude/skills/plecs-expert/references/solver.md
@@ -1,0 +1,253 @@
+# solver
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-simulation-time -->
+
+| Name | Description |
+| --- | --- |
+| Start Time | The start time specifies the initial value of the simulation time variable \(t\) at the beginning of a simulation, in seconds \((\mathrm{s})\) . If a simulation is started from a stored system state (see System State ), this parameter is ignored and the simulation time specified in the system state is used instead. |
+| Time Span | The simulation ends when the simulation time has advanced by the specified time span. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-simulation-time -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-solver -->
+
+| Name | Description |
+| --- | --- |
+| Variable-step | A variable-step solver can adopt the step size during the simulation depending on model dynamics. At times of rapid state changes the step size is reduced to maintain accuracy; when the model states change only slowly, the step size is increased to save unnecessary computations. The step size can also be adjusted in order to accurately simulate discontinuities. For these reasons, a variable-step solver should generally be preferred. DOPRI is a variable-step solver using a fifth-order accurate explicit Runge-Kutta formula (the Dormand-Prince pair). This solver is most efficient for non-stiff systems and is selected by default. A stiff system can be sloppily defined as one having time constants that differ by several orders of magnitudes. Such a system forces a non-stiff solver to choose excessively small time steps. If DOPRI detects stiffness in a system, it will abort the simulation with the recommendation to switch to a stiff solver. RADAU is a variable-step solver for stiff systems using a fifth-order accurate fully-implicit three-stage Runge-Kutta formula (Radau IIA). For non-stiff systems DOPRI is more efficient than RADAU. When auto is selected, PLECS starts a simulation with DOPRI and automatically switches to RADAU if the system is found to become stiff during a simulation. This is the default choice for a variable-step solver. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-solver -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-solver-2 -->
+
+| Name | Description |
+| --- | --- |
+| Fixed-step | The fixed-step solver Discrete does not actually solve any differential equations but just advances the simulation time with fixed increments. If this solver is chosen, the linear state-space equations of the physical model are discretized as described in section Physical Model Discretization . All other continuous state variables are updated using the Forward Euler method. Events and discontinuities that occur between simulation steps are accounted for by a linear interpolation method. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-solver-2 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-variable-step-solver-options -->
+
+| Name | Description |
+| --- | --- |
+| Max Step Size | The maximum step size specifies the largest time step that the solver can take and should not be chosen unnecessarily small. If you suspect that the solver is missing events, try reducing the maximum step size. However, if you just require more output points for smoother curves, you should increase the refine factor (see below). |
+| Initial Step Size | This parameter can be used to suggest a step size to be used for the first integration step. The default setting auto causes the solver to choose the step size according to the initial state derivatives. You should only change this parameter if you suspect that the solver is missing an event at the beginning of a simulation. |
+| Tolerances | The relative and absolute specify the acceptable local integration errors for the individual state variables according to: \[\mathrm{err}_i \le \mathrm{rtol}\cdot \|x_i\| + \mathrm{atol}_i\] If all error estimates are smaller than the limit, the solver will increase the step size for the following step. If any error estimate is larger than the limit, the solver will discard the current step and repeat it with a smaller step size. The default absolute tolerance setting auto causes the solver to update the absolute tolerance for each state variable individually, based on the maximum absolute value encountered so far. |
+| Refine factor | The refine factor is an efficient method for generating additional output points in order to achieve smoother results. For each successful integration step, the solver calculates \(r-1\) intermediate steps by interpolating the continuous states based on a higher-order polynomial. This is computationally much cheaper than reducing the maximum step size (see above). |
+| Jacobian computation | This parameter specifies how the solver calculates the Jacobian matrix required for the integration of stiff systems. The default setting analytical uses exact derivatives provided by the model for improved accuracy and performance. Select finite differences to revert to the legacy method, where the Jacobian is approximated numerically by perturbing each state variable. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-variable-step-solver-options -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-fixed-step-solver-options -->
+
+| Name | Description |
+| --- | --- |
+| Fixed step size | This parameter specifies the fixed time increments for the solver and also the sample time used for the state-space discretization of the physical model. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-fixed-step-solver-options -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-circuit-model-options -->
+
+| Name | Description |
+| --- | --- |
+| Diode Turn-On Threshold | This parameter globally controls the turn-on behavior of line commutated devices such as diodes, thyristors, GTOs and similar semiconductors. A diode starts conducting as soon as the voltage across it becomes larger than the sum of the forward voltage and the threshold voltage. Similar conditions apply to the other line commutated devices. The default value for this parameter is 0 . For most applications the threshold could also be set to zero. However, in certain cases it is necessary to set this parameter to a small positive value to prevent line commutated devices from bouncing. Bouncing occurs if a switch receives an opening command and a closing command repeatedly in subsequent simulation steps or even within the same simulation step. Such a situation can arise in large, stiff systems that contain many interconnected switches. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-circuit-model-options -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-circuit-model-options-2 -->
+
+| Name | Description |
+| --- | --- |
+| Non-ideal switch resistance (code generation) | This parameter specifies the resistance for non-ideal switches when generating code from a simulation model. For details refer to section Ideal and Non-Ideal Switch Models in Electric Circuits . |
+| Disc. method | This parameter determines the algorithm used to discretize the state-space equations of the electro-magnetic model. |
+| ZC step size | This parameter is used by the Switch Manager when a non-sampled event (usually the zero crossing of a current or voltage) is detected. It controls the relative size of a step taken across the event. The default is 1e-9 . |
+| Tolerances | The error tolerances are used to check whether the state variables are consistent after a switching event. The defaults are 1e-3 for the relative tolerance and 1e-6 for the absolute tolerance. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-circuit-model-options-2 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-sample-times -->
+
+| Name | Description |
+| --- | --- |
+| Synchronize fixed-step sample times | This option specifies whether PLECS should attempt to find a common base sample rate for blocks that specify a discrete sample time. |
+| Use single base sample rate | This option specifies whether PLECS should attempt to find a single common base sample rate for all blocks that specify a discrete sample time. These options can only be modified for a variable-step solver; for a fixed-step solver they are checked by default. For details see section Multirate Systems . |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-sample-times -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-state-space-calculation -->
+
+| Name | Description |
+| --- | --- |
+| Use extended precision | When this option is checked, PLECS uses higher-precision arithmetics for the internal calculation of the state-space matrices for a physical model. Check this option if PLECS reports that the system matrix is close to singular. |
+| Remove unused state-space outputs | When this option is checked, PLECS removes the output equations for physical meters that are not used in the model in order to avoid unnecessary calculations. You may need to uncheck this option if you want to calculate state-space matrices in a simulation script, see Extraction of State-Space Matrices . By default, this option is checked. |
+| Enable state-space splitting | When this option is checked, PLECS will attempt to split the state-space model for a physical domain into smaller independent models that can be calculated and updated individually. This can reduce the calculation effort at runtime, which is particularly advantageous for real-time simulations. |
+| Display state-space splitting | When this option is checked, PLECS will issue diagnostic messages that highlight the components that make up the individual state-space models after splitting. This is useful e.g. in order to connect Model Settings blocks in the appropriate places (see Electrical Model Settings , Rotational Model Settings and Translational Model Settings ). |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-state-space-calculation -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-data-types -->
+
+| Name | Description |
+| --- | --- |
+| Use floating-point data type for fixed-point signals | When this option is enabled, PLECS will replace all fixed-point data types with the target floating-point data type (see section Data Types ). |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-data-types -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-assertions -->
+
+| Name | Description |
+| --- | --- |
+| Assertion action | Use this option to override the action that is executed when an assertion fails (see Assertion block ). The default is use local settings , which uses the actions specified in each individual assertion. Assertions with the individual setting ignore are always ignored, even if this option is different from use local settings . Note that during analyses and simulation scripts, assertions may be partly disabled (see section Assertions ). |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-assertions -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-algebraic-loops -->
+
+| Name | Description |
+| --- | --- |
+| Method | Use this option to select the strategy adopted by the nonlinear equation solver. Currently, either a line search method or a trust region method can be used. |
+| Tolerance | The relative error bound. The solver updates the block outputs iteratively until the maximum relative change from one iteration to the next and the maximum relative residual of the loop equations are both smaller than this value. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-algebraic-loops -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-diagnostics -->
+
+| Name | Description |
+| --- | --- |
+| Division by zero | This option determines the diagnostic action to take if PLECS encounters a division by zero in a Product block or a Function block . A division by zero yields \(\pm\infty\) or nan (“not a number”, if you divide \(0/0\) ). Using these values as inputs for other blocks may lead to unexpected model behavior. Possible choices are ignore , warning and error . In new models, the default is error . |
+| Datatype overflow | This option determines the diagnostic action to take if PLECS encounters a data type overflow. PLECS can issue an error or a warning message or can continue silently. In the latter two cases, the result is handled according to the individual data type overflow handling setting of the block. If the individual setting is Assert with error , PLECS always issues an error message. |
+| Datatype inheritance conflict | This option allows to apply less strict data type inheritance rules (see section Data Types ). In new models, the default is error . |
+| Continuous sample time conflict | This option determines the diagnostic action to take if PLECS detects a continuous sample time conflict (see section Continuous Sample Time Conflicts ). In new models, the default is error . |
+| Negative switch loss | This option determines the diagnostic action to take if PLECS encounters negative loss values during the calculation of switch losses (see section Loss Calculation ). PLECS can issue an error or a warning message or can continue silently. In the latter two cases, the losses that are injected into the thermal model are cropped to zero. |
+| Stiffness detection | This parameter only applies to the non-stiff, variable-step DOPRI solver. The DOPRI solver contains an algorithm to detect when a model becomes “stiff” during the simulation. Stiff models cannot be solved efficiently with non-stiff solvers, because they constantly need to adjust the step size at relatively small values to keep the solution from becoming numerically unstable. If the DOPRI solver detects stiffness in model, it will raise a warning or error message depending on this parameter setting with the recommendation to use the stiff RADAU solver instead. |
+| Max. number of consecutive zero-crossings | This parameter only applies to variable-step solvers. For a model that contains discontinuities (also termed “zero-crossings”), a variable-step solver will reduce the step size so as to make a simulation step precisely at the time when a discontinuity occurs (see section Event Detection Loop ). If many discontinuities occur in subsequent steps, the simulation may come to an apparent halt without actually stopping because the solver is forced to reduce the step size to an excessively small value. This parameter specifies an upper limit for the number of discontinuities in consecutive simulation steps before PLECS stops the simulation with an error message that shows the responsible component(s). To disable this diagnostic, set this parameter to 0 . |
+| Algebraic loop with state machines | This option determines the diagnostic action to take if PLECS detects an algebraic loop that includes a State Machine . This may lead to unexpected behavior because the state machine will be executed multiple times for the same simulation step during the iterative solution of the algebraic loop. Possible choices are ignore , warning and error . The default is error . |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-diagnostics -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-system-state -->
+
+| Name | Description |
+| --- | --- |
+| Block parameters | When this option is selected, the state variables are initialized with the values specified in the individual block parameters. |
+| Stored system state | When this option is selected, the state variables are initialized globally from a previously stored system state; the initial values specified in the individual block parameters are ignored. This option is disabled if no state has been stored. |
+| Store system state… | Pressing this button after a transient simulation run or an analysis will store the final system state along with a time stamp and an optional comment. When you save the model, this information will be stored in the model file so that it can be used in future sessions. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-system-state -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-id1 -->
+
+| Name | Description |
+| --- | --- |
+| Diode Turn-On Threshold | This parameter globally controls the turn-on behavior of line commutated devices such as diodes, thyristors, GTOs and similar semiconductors. A diode starts conducting as soon as the voltage across it becomes larger than the sum of the forward voltage and the threshold voltage. Similar conditions apply to the other line commutated devices. The default value for this parameter is 1e-3 . For most applications the threshold could also be set to zero. However, in certain cases it is necessary to set this parameter to a small positive value to prevent line commutated devices from bouncing. Bouncing occurs if a switch receives an opening command and a closing command repeatedly in subsequent simulation steps or even within the same simulation step. Such a situation can arise in large, stiff systems that contain many interconnected switches. Note The Diode Turn-On Threshold is not equivalent to the voltage drop across a device when it is conducting. The turn-on threshold only delays the instant when a device turns on. The voltage drop across a device is solely determined by the forward voltage and/or on-resistance specified in the device parameters. |
+| Type | This parameter lets you choose between the continuous and discrete state-space method for setting up the physical model equations. For details please refer to section Physical Model Equations . When you choose Continuous state-space , PLECS employs the Simulink solver to solve the differential equations and integrate the state variables. The Switch Manager communicates with the solver in order to ensure that switching occurs at the correct time. This is done with Simulink’s zero-crossing detection capability. For this reason the continuous method can only be used with a variable-step solver. In general, the default solver of Simulink, ode45 , is recommended. However, your choice of circuit parameters may lead to stiff differential equations, e.g. if you have large resistors connected in series with inductors. In this case you should choose one of Simulink’s stiff solvers. When you choose Discrete state-space , PLECS discretizes the linear state-space equations of the physical model as described in section Physical Model Discretization . All other continuous state variables are updated using the Forward Euler method. This method can be used with both variable-step and fixed-step solvers. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-id1 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-discrete-state-space-options -->
+
+| Name | Description |
+| --- | --- |
+| Sample time | This parameter determines the rate with which Simulink samples the circuit. A setting of auto or -1 means that the sample time is inherited from the Simulink model. |
+| Refine factor | This parameter controls the internal step size which PLECS uses to discretize the state-space equations. The discretization time step \(\Delta t\) is thus calculated as the sample time divided by the refine factor. The refine factor must be a positive integer. The default is 1 . Choosing a refine factor larger than 1 allows you to use a sample time that is convenient for your discrete controller while at the same time taking into account the usually faster dynamics of the electrical system. |
+| Disc. method | This parameter determines the algorithm used to discretize the state-space equations of the electro-magnetic model. |
+| ZC step size | This parameter is used by the Switch Manager when a non-sampled event (usually the zero crossing of a current or voltage) is detected. It controls the relative size of a step taken across the event. The default is 1e-9 . |
+| Tolerances | The error tolerances are used to check whether the state variables are consistent after a switching event. The defaults are 1e-3 for the relative tolerance and 1e-6 for the absolute tolerance. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-discrete-state-space-options -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-id2 -->
+
+| Name | Description |
+| --- | --- |
+| Zero crossing detection disabled | In order to accurately determine the proper switching times of power semiconductors, PLECS highly depends on the solver’s capability to locate zero crossings. If you switch off the zero crossing detection in the Simulink solver or use the less accurate “Adaptive” detection algorithm, PLECS will therefore issue a diagnostic message. This option allows you to specify the severity level ( warning or error ) of this message. If you encounter problems due to many consecutive zero crossings, it is usually not advisable to modify the zero crossing detection settings. Consecutive zero crossings are often caused by insufficient simulation accuracy, typically in conjunction with a stiff model. In this case it may help to tighten the relative tolerance of the Simulink solver (from the default 1e-3 to 1e-5 or 1e-6 ) and to switch from the default solver ode45 to a stiff solver such as ode23tb and, where applicable, set the Simulink solver option Solver reset method to Robust . |
+| Number of consecutive gate signal changes | If you configure a Signal Inport block in a top-level schematic to be a gate signal , PLECS expects this signal to change only at discrete instants. If instead the signal changes in more than the specified number of consecutive simulation time steps, PLECS will issue an error message to indicate that there may be a problem in the gate signal generator. You can disable this diagnostic by entering 0 . |
+| Division by zero | This option determines the diagnostic action to take if PLECS encounters a division by zero in a Product block or a Function block . A division by zero yields \(\pm\infty\) or nan (“not a number”, if you divide \(0/0\) ). Using these values as inputs for other blocks may lead to unexpected model behavior. Possible choices are ignore , warning and error . In new models, the default is error . |
+| Datatype overflow | This option determines the diagnostic action to take if PLECS encounters a data type overflow. PLECS can issue an error or a warning message or can continue silently. In the latter two cases, the result is handled according to the individual data type overflow handling setting of the block. If the individual setting is Assert with error , PLECS always issues an error message. |
+| Datatype inheritance conflict | This option allows to apply less strict data type inheritance rules (see section Data Types ). In new models, the default is error . |
+| Continuous sample time conflict | This option determines the diagnostic action to take if PLECS detects a continuous sample time conflict (see section Continuous Sample Time Conflicts ). In new models, the default is error . |
+| Algebraic loop with state machines | This option determines the diagnostic action to take if PLECS detects an algebraic loop that includes a State Machine . This may lead to unexpected behavior because the state machine will be executed multiple times for the same simulation step during the iterative solution of the algebraic loop. Possible choices are ignore , warning and error . The default is error . |
+| Negative switch loss | This option determines the diagnostic action to take if PLECS encounters negative loss values during the calculation of switch losses (see section Loss Calculation ). PLECS can issue an error or a warning message or can continue silently. In the latter two cases, the losses that are injected into the thermal model are cropped to zero. |
+| Assertion action | Use this option to override the action that is executed when an assertion fails (see Assertion block ). The default is use local settings , which uses the actions specified in each individual assertion. Assertions with the individual setting ignore are always ignored, even if this option is different from use local settings . Note that during analyses and simulation scripts, assertions may be partly disabled (see Assertions ). |
+| Use floating-point data type for fixed-point signals | When this option is enabled, PLECS will replace all fixed-point data types with the target floating-point data type (see section Data Types ). |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-id2 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-id3 -->
+
+| Name | Description |
+| --- | --- |
+| Synchronize fixed-step sample times | This option specifies whether PLECS should attempt to find a common base sample rate for blocks that specify a discrete sample time. |
+| Use single base sample rate | This option specifies whether PLECS should attempt to find a single common base sample rate for all blocks that specify a discrete sample time. These options can only be modified for a Continuous State-Space model; for a Discrete State-Space model they are checked by default. For details see section Multirate Systems . |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-id3 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-id4 -->
+
+| Name | Description |
+| --- | --- |
+| Method | Use this option to select the strategy adopted by the nonlinear equation solver. Currently, either a line search method or a trust region method can be used. |
+| Tolerance | The relative error bound. The solver updates the block outputs iteratively until the maximum relative change from one iteration to the next and the maximum relative residual of the loop equations are both smaller than this value. |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-id4 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-id5 -->
+
+| Name | Description |
+| --- | --- |
+| Use extended precision | When this option is checked, PLECS uses higher-precision arithmetics for the internal calculation of the state-space matrices for a physical model. Check this option if PLECS reports that the system matrix is close to singular. |
+| Remove unused state-space outputs | When this option is checked, PLECS removes the output equations for physical meters that are not used in the model in order to avoid unnecessary calculations. You may need to uncheck this option if you want to calculate state-space matrices in a simulation script, see Extraction of State-Space Matrices . By default, this option is checked. |
+| Enable state-space splitting | When this option is checked, PLECS will attempt to split the state-space model for a physical domain into smaller independent models that can be calculated and updated individually. This can reduce the calculation effort at runtime, which is particularly advantageous for real-time simulations. |
+| Display state-space splitting | When this option is checked, PLECS will issue diagnostic messages that highlight the components that make up the individual state-space models after splitting. This is useful e.g. in order to connect Model Settings blocks in the appropriate places (see Electrical Model Settings , Rotational Model Settings and Translational Model Settings ). |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-id5 -->
+
+<!-- BEGIN VERBATIM TABLE: simulation-parameters-simulink-coder -->
+
+| Name | Description |
+| --- | --- |
+| Target | This option specifies the code generation target that is used when you generate code with the Simulink Coder. For details on the available targets see section Target . |
+| Inline circuit parameters for RSim target | This option controls whether PLECS inlines parameter values or whether it should keep them tunable when it creates code for the RSim target. For details see section Tunable Circuit Parameters in Rapid Simulations . |
+
+_Source: https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/_
+
+<!-- END VERBATIM TABLE: simulation-parameters-simulink-coder -->

--- a/.claude/skills/plecs-expert/references/url-index.md
+++ b/.claude/skills/plecs-expert/references/url-index.md
@@ -1,0 +1,30 @@
+# URL Fallback Index
+
+Topics not covered offline. Skill must `WebFetch` URL, summarize caveman style, cite URL.
+
+All URLs verified 200 OK on 2026-04-27 via `curl -L`.
+
+| Topic | URL |
+|-------|-----|
+| RT Box product page (covered by future plecs-rtbox skill) | https://www.plexim.com/products/rt_box |
+| Field-oriented control transforms (Park / Clarke / D-Q) | https://docs.plexim.com/plecs/latest/components-by-category/abc2dq/ |
+| Saturable inductor component | https://docs.plexim.com/plecs/latest/components-by-category/saturableinductor/ |
+| Configurable subsystem variants | https://docs.plexim.com/plecs/latest/components-by-category/conf_subsystem/ |
+| PLECS Coder / code generation root | https://docs.plexim.com/plecs/latest/codegeneration/ |
+| Solver tolerance tuning (simulation parameters) | https://docs.plexim.com/plecs/latest/using-plecs/simulation-parameters/ |
+| MATLAB / Simulink scripting integration | https://docs.plexim.com/plecs/latest/scripting/ |
+| Modulator block library (symmetrical PWM example) | https://docs.plexim.com/plecs/latest/components-by-category/symmetricalpwm/ |
+| Three-phase machines (PMSM example) | https://docs.plexim.com/plecs/latest/components-by-category/pmsm/ |
+| Power semiconductor thermal modeling (thermal library) | https://docs.plexim.com/plecs/latest/thermal-modeling/thermal-library/ |
+
+## Notes
+
+Topic catalog hand-built. Original `/UserManual/<Subdir>/<File>.html` slugs all 404 — Plexim uses `/components-by-category/<slug>/` and `/<topic>/` instead. Slugs above probed via curl + index pages on 2026-04-27.
+
+No dedicated FOC library page. Closest match: D-Q / Clarke transform components under `components-by-category/`.
+
+No dedicated MATLAB integration page. MATLAB content lives under `scripting/` (Command Line Interface in PLECS Blockset).
+
+No dedicated target-support list page. PLECS Coder targets ship as separate target-support packages — start at `codegeneration/`.
+
+RT Box has no `docs.plexim.com/rtbox/` subdomain. Product overview at `plexim.com/products/rt_box`.

--- a/.claude/skills/plecs-expert/style/caveman.md
+++ b/.claude/skills/plecs-expert/style/caveman.md
@@ -1,3 +1,47 @@
-# Caveman Style (placeholder — populated in Task 2)
+# Caveman Style — Prose Rules for plecs-expert
 
-See https://github.com/juliusbrussee/caveman.
+Reference: https://github.com/juliusbrussee/caveman
+
+## Core rule
+
+Drop: articles, filler, hedging, pleasantries.
+Fragments OK.
+Pattern: `[thing] [action] [reason]. [next step].`
+Code blocks: never modified — kept exactly as authored.
+
+## Banned words (enforced by `tests/test_plecs_expert.py::test_caveman_compliance`)
+
+`basically`, `really`, `actually`, `essentially`, `obviously`, `simply`, `just`, `very`, `quite`, `perhaps`, `maybe`.
+
+## Allow marker
+
+If a banned word is unavoidable (rare), include the literal marker `<!-- caveman:allow -->` anywhere in the file. The whole file is then exempt. Use sparingly; comment why.
+
+## Examples
+
+**Bad:**
+> The Inductor block is basically just a passive component that really stores energy in a magnetic field. You can simply set its initial current via the IL_init parameter.
+
+**Good (caveman):**
+> Inductor block. Passive. Stores energy in magnetic field. Param `IL_init` sets initial current.
+
+**Bad:**
+> Note that the MOSFET model is actually quite detailed and includes both conduction and switching losses if you configure it properly.
+
+**Good (caveman):**
+> MOSFET model. Conduction + switching loss. Enable via `model_level=2`.
+
+## What's verbatim, what's rewritten
+
+| Section type | Posture |
+|--------------|---------|
+| Parameter tables | Verbatim (facts) |
+| RPC function signatures | Verbatim (facts) |
+| XML element grammar | Verbatim (facts) |
+| Defaults & units | Verbatim (facts) |
+| Explanatory prose | Rewritten in caveman style |
+| Examples (our own) | Caveman style |
+
+## Style guide for tables
+
+Tables are facts. Keep verbatim from docs.plexim.com. Add a `Source:` line below each table pointing to the source URL.

--- a/.claude/skills/plecs-expert/style/caveman.md
+++ b/.claude/skills/plecs-expert/style/caveman.md
@@ -1,0 +1,3 @@
+# Caveman Style (placeholder — populated in Task 2)
+
+See https://github.com/juliusbrussee/caveman.

--- a/.claude/skills/plecs-expert/tools/REFRESH.md
+++ b/.claude/skills/plecs-expert/tools/REFRESH.md
@@ -1,0 +1,56 @@
+# Refresh Procedure
+
+Run on every PLECS minor-version bump or quarterly, whichever is sooner.
+
+## 1. Detect drift
+
+```bash
+python .claude/skills/plecs-expert/tools/check_drift.py
+```
+
+Output is a Markdown report. Two sections:
+
+- **Docs drift** — tables changed upstream. `sync_tables.py` will re-fetch.
+- **PyPLECS drift** — wrappers or RPC methods added/removed since last snapshot. Update `references/` wrapped-vs-not-wrapped notes accordingly.
+
+If both sections say "no drift", you're done.
+
+## 2. Re-sync verbatim tables
+
+```bash
+python .claude/skills/plecs-expert/tools/sync_tables.py
+```
+
+Updates `<!-- BEGIN VERBATIM TABLE: ... -->` blocks in place. Prose between blocks untouched.
+
+## 3. Re-author flagged prose
+
+For each `DRIFT` line in step 1's report, open the listed file and re-author the surrounding caveman-style prose. Apply `style/caveman.md`.
+
+For each `ADDED`/`REMOVED` line, update the relevant `references/components/*.md` to flip its "wrapped via `pyplecs.<class>`" / "not wrapped, see SPICE map" notes.
+
+## 4. Update pyplecs snapshot
+
+```bash
+python -c "
+import json, sys
+sys.path.insert(0, '.claude/skills/plecs-expert/tools')
+from check_drift import pyplecs_snapshot
+m = json.load(open('.claude/skills/plecs-expert/manifest.json'))
+m['pyplecs_snapshot'] = pyplecs_snapshot()
+json.dump(m, open('.claude/skills/plecs-expert/manifest.json','w'), indent=2)
+"
+```
+
+## 5. Bump version pin
+
+Edit `manifest.json`'s `plecs_version_pinned` if PLECS minor changed.
+
+## 6. Verify + commit
+
+```bash
+ruff check .
+pytest tests/test_plecs_expert.py
+git add .claude/skills/plecs-expert
+git commit -m "chore(skill): refresh plecs-expert against PLECS X.Y"
+```

--- a/.claude/skills/plecs-expert/tools/check_drift.py
+++ b/.claude/skills/plecs-expert/tools/check_drift.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Detect drift between manifest hashes and current docs / pyplecs surface.
+
+Two checks:
+
+1. **Docs drift**: re-fetch each URL in manifest.json, hash extracted tables,
+   compare to stored hashes. Report which references/*.md need a sync.
+
+2. **PyPLECS drift**: introspect `pyplecs.plecs_components` and
+   `pyplecs.pyplecs.PlecsServer`. Diff against the snapshot stored under
+   manifest.json's `pyplecs_snapshot` key. Report wrappers added/removed and
+   RPC methods added/removed.
+
+Output is a Markdown report on stdout. Exit code: 0 if no drift, 1 otherwise.
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import sys
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = SKILL_ROOT / "manifest.json"
+
+# Reuse extraction logic from sync_tables to keep hashes consistent
+sys.path.insert(0, str(SKILL_ROOT / "tools"))
+from sync_tables import extract_tables, fetch  # noqa: E402
+
+
+def docs_drift(manifest: dict) -> list[str]:
+    issues: list[str] = []
+    for rel_file, entry in manifest["files"].items():
+        stored = entry.get("table_section_hashes", {})
+        for url in entry["source_urls"]:
+            try:
+                html = fetch(url)
+            except Exception as exc:
+                issues.append(f"- FETCH FAILED `{rel_file}` ← {url}: {exc}")
+                continue
+            for slug, body in extract_tables(html, url).items():
+                h = hashlib.sha256(body.encode("utf-8")).hexdigest()
+                if stored.get(slug) != h:
+                    issues.append(f"- DRIFT `{rel_file}` table `{slug}` (source: {url})")
+    return issues
+
+
+def pyplecs_snapshot() -> dict:
+    """Live introspection of pyplecs surface."""
+    import pyplecs.plecs_components as comps
+    from pyplecs.pyplecs import PlecsServer
+
+    wrappers = sorted(
+        n for n, obj in inspect.getmembers(comps, inspect.isclass)
+        if obj.__module__ == comps.__name__
+    )
+    rpc_methods = sorted(
+        n for n, _ in inspect.getmembers(PlecsServer, predicate=inspect.isfunction)
+        if not n.startswith("_")
+    )
+    return {"wrappers": wrappers, "rpc_methods": rpc_methods}
+
+
+def pyplecs_drift(manifest: dict) -> list[str]:
+    current = pyplecs_snapshot()
+    stored = manifest.get("pyplecs_snapshot", {"wrappers": [], "rpc_methods": []})
+    issues: list[str] = []
+    for kind in ("wrappers", "rpc_methods"):
+        added = set(current[kind]) - set(stored[kind])
+        removed = set(stored[kind]) - set(current[kind])
+        for name in sorted(added):
+            issues.append(f"- ADDED {kind}: `{name}` — update `references/` wrapped/not-wrapped status")
+        for name in sorted(removed):
+            issues.append(f"- REMOVED {kind}: `{name}` — was wrapped, now isn't; update references/")
+    return issues
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    docs = docs_drift(manifest)
+    pyp = pyplecs_drift(manifest)
+    print("# Drift Report\n")
+    print("## Docs drift\n")
+    print("\n".join(docs) if docs else "_no docs drift_")
+    print("\n## PyPLECS drift\n")
+    print("\n".join(pyp) if pyp else "_no pyplecs drift_")
+    return 1 if (docs or pyp) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/plecs-expert/tools/sync_tables.py
+++ b/.claude/skills/plecs-expert/tools/sync_tables.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Scrape factual tables from PLECS docs into references/*.md.
+
+Reads URLs from manifest.json. For each URL:
+  1. Fetches HTML (httpx).
+  2. Extracts <table> elements (BeautifulSoup).
+  3. Renders each as a Markdown table.
+  4. Writes/updates the verbatim sections of the corresponding references/*.md
+     file, preserving any prose between BEGIN/END markers.
+
+Per-section markers are HTML comments:
+  <!-- BEGIN VERBATIM TABLE: <slug> -->
+  ...table markdown...
+  <!-- END VERBATIM TABLE: <slug> -->
+
+Prose between marker pairs is left untouched. Hashes are written to
+manifest.json so check_drift.py can detect upstream changes.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = SKILL_ROOT / "manifest.json"
+
+BEGIN_RE = re.compile(r"<!--\s*BEGIN VERBATIM TABLE:\s*(?P<slug>[^\s-]+)\s*-->")
+END_RE = re.compile(r"<!--\s*END VERBATIM TABLE:\s*(?P<slug>[^\s-]+)\s*-->")
+
+
+def slugify(url: str) -> str:
+    return Path(url.rstrip("/")).name.replace(".html", "").lower()
+
+
+def _clean_cell(text: str) -> str:
+    """Escape pipes and collapse whitespace so the cell is markdown-safe."""
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def html_table_to_markdown(table: Tag) -> str:
+    rows: list[list[str]] = []
+    for tr in table.find_all("tr"):
+        cells = [_clean_cell(td.get_text(" ", strip=True)) for td in tr.find_all(["td", "th"])]
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    width = max(len(r) for r in rows)
+    rows = [r + [""] * (width - len(r)) for r in rows]
+    out = ["| " + " | ".join(rows[0]) + " |"]
+    out.append("| " + " | ".join(["---"] * width) + " |")
+    for r in rows[1:]:
+        out.append("| " + " | ".join(r) + " |")
+    return "\n".join(out)
+
+
+def dl_to_markdown(dl: Tag, header: tuple[str, str] = ("Name", "Description")) -> str:
+    """Render a <dl>...</dl> as a 2-column Markdown table.
+
+    PLECS docs encode component parameters and probe signals as definition
+    lists rather than HTML tables. The dt is the parameter/probe name and
+    the dd is its description (factual: units, defaults, ranges).
+    """
+    rows: list[tuple[str, str]] = []
+    dts = dl.find_all("dt", recursive=False)
+    dds = dl.find_all("dd", recursive=False)
+    for dt, dd in zip(dts, dds):
+        name = _clean_cell(dt.get_text(" ", strip=True))
+        desc = _clean_cell(dd.get_text(" ", strip=True))
+        if name or desc:
+            rows.append((name, desc))
+    if not rows:
+        return ""
+    out = [f"| {header[0]} | {header[1]} |", "| --- | --- |"]
+    for name, desc in rows:
+        out.append(f"| {name} | {desc} |")
+    return "\n".join(out)
+
+
+def fetch(url: str) -> str:
+    resp = httpx.get(url, timeout=30, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.text
+
+
+PROBE_SECTIONS = {"probes", "probe-signals", "probe_signals"}
+
+
+def _enclosing_section_id(node: Tag) -> str:
+    for anc in node.parents:
+        if getattr(anc, "name", None) == "section" and anc.get("id"):
+            return anc.get("id")  # type: ignore[return-value]
+    return "section"
+
+
+def extract_tables(html: str, url: str) -> dict[str, str]:
+    """Extract factual tables from a PLECS doc page.
+
+    PLECS docs encode facts in two markups:
+      * <table>...</table> (used on RPC / codegen / scripting pages).
+      * <dl><dt>name</dt><dd>desc</dd>...</dl> for parameter and probe
+        listings (used on every component page and on solver pages).
+    Both are rendered to Markdown tables.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    base_slug = slugify(url)
+    out: dict[str, str] = {}
+    used_slugs: set[str] = set()
+
+    def _add(slug: str, body: str) -> None:
+        candidate = slug
+        idx = 1
+        while candidate in used_slugs:
+            idx += 1
+            candidate = f"{slug}-{idx}"
+        used_slugs.add(candidate)
+        out[candidate] = body
+
+    # 1) Native HTML tables.
+    for i, t in enumerate(soup.find_all("table")):
+        md = html_table_to_markdown(t)
+        if md:
+            _add(f"{base_slug}-table-{i}", md)
+
+    # 2) Top-level <dl> elements (skipping nested dls). Slug by enclosing
+    #    section id so multiple parameter blocks on the same page stay
+    #    distinct (e.g. solver page has 21 dls across 14 sections).
+    for dl in soup.find_all("dl"):
+        if dl.find_parent("dl") is not None:
+            continue
+        sec_id = _enclosing_section_id(dl)
+        header = (
+            ("Probe signal", "Description")
+            if sec_id in PROBE_SECTIONS
+            else ("Name", "Description")
+        )
+        md = dl_to_markdown(dl, header=header)
+        if md:
+            _add(f"{base_slug}-{sec_id}", md)
+    return out
+
+
+def replace_section(text: str, slug: str, body: str) -> str:
+    begin = f"<!-- BEGIN VERBATIM TABLE: {slug} -->"
+    end = f"<!-- END VERBATIM TABLE: {slug} -->"
+    pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    block = f"{begin}\n\n{body}\n\n{end}"
+    if pattern.search(text):
+        return pattern.sub(block, text)
+    sep = "\n\n" if text and not text.endswith("\n") else "\n"
+    return text + sep + block + "\n"
+
+
+def update_file(target: Path, sections: dict[str, str], source_url: str) -> dict[str, str]:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    text = target.read_text(encoding="utf-8") if target.exists() else f"# {target.stem}\n"
+    hashes: dict[str, str] = {}
+    for slug, body in sections.items():
+        marked = f"{body}\n\n_Source: {source_url}_"
+        text = replace_section(text, slug, marked)
+        hashes[slug] = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    target.write_text(text, encoding="utf-8")
+    return hashes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    for rel_file, entry in manifest["files"].items():
+        target = SKILL_ROOT / rel_file
+        all_hashes: dict[str, str] = {}
+        for url in entry["source_urls"]:
+            try:
+                html = fetch(url)
+            except Exception as exc:
+                failures.append(f"FETCH {url}: {exc}")
+                continue
+            sections = extract_tables(html, url)
+            if not sections:
+                failures.append(f"NO TABLES {url}")
+                continue
+            if args.dry_run:
+                print(f"[dry-run] {rel_file} <- {len(sections)} tables from {url}")
+                continue
+            new_hashes = update_file(target, sections, url)
+            all_hashes.update(new_hashes)
+        if not args.dry_run:
+            entry["table_section_hashes"] = all_hashes
+    if not args.dry_run:
+        MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_fu
 - **Two layers** (full detail in [architecture.md](docs/architecture.md)): `pyplecs/pyplecs.py` is a thin XML-RPC wrapper over PLECS; the orchestration / cache / api / webgui packages are built on top.
 - **Tool-agnostic ABCs at `pyplecs.contracts`** — public façade that prefers an installed PyPI `pycircuitsim_core` (when major-version-compatible) and falls back to the vendored copy at `pyplecs/_contracts/`. **Hard rule:** PyPLECS is standalone — never add `pycircuitsim-core` to `pyproject.toml` dependencies. See `tools/SYNC_PYCIRCUITSIM_CORE.md` for re-sync procedure.
 - **Optional deps degrade to `None`** — `pyplecs/__init__.py` sets `PlecsServer`, `create_api_app`, `create_web_app`, etc. to `None` when their optional packages aren't installed; callers must handle `None`.
+- **PLECS docs reference at `.claude/skills/plecs-expert/`** — single source of truth for the skill, `/plecs` command, and `pyplecs-mcp` MCP server. Refresh procedure in `.claude/skills/plecs-expert/tools/REFRESH.md`.
 
 ## Key Documents
 - [PRD](docs/prd.md) — requirements and roadmap
@@ -25,6 +26,7 @@ pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_fu
 - [Install](docs/install.md) — installation and configuration
 - [Migration](docs/migration.md) — v0.x to v1.0.0 upgrade
 - [Contributing](docs/contributing.md) — development workflow
+- [PLECS Expert Skill](.claude/skills/plecs-expert/SKILL.md) — PLECS docs reference (offline + URL fallback)
 
 ## Specs & Plans
 - Specs: `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
@@ -54,3 +56,4 @@ Central pool (WSL): `\\wsl$\Ubuntu\home\tinix\claude_wsl\agents_pool\` | Domain:
 | 2026-04-25 | Vendor `pycircuitsim_core` ABCs at `pyplecs/_contracts/`, expose via `pyplecs.contracts` façade with PyPI passthrough | PyPLECS must work standalone (no transitive dep on `pycircuitsim-core`); umbrella PyCircuitSim ecosystem is auto-detected when present. Vendored copy stays forever; no exit clause. |
 | 2026-04-25 | Move `articles/` under `docs/articles/` | Ship long-form posts via mkdocs to GitHub Pages instead of bloating repo root. |
 | 2026-04-25 | Unify lint on ruff (drop black/flake8/mypy/isort) | Single tool covers format + lint + isort; one config in `pyproject.toml`. |
+| 2026-04-27 | Add `plecs-expert` skill + `pyplecs-mcp` MCP server | Ground PLECS authoring help, netlist converter, and PlecsServer wrapper in docs.plexim.com via offline caveman-style reference. Closes #23. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,10 @@
 pip install -e ".[dev]"        # ruff + pytest
 ruff check .                   # lint (must be clean)
 pytest                         # full suite (Windows + PLECS on port 1080)
-pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py  # platform-independent subset
+pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py tests/test_plecs_expert.py  # platform-independent subset
 ```
 
-**No GitHub Actions CI.** A Claude Code pre-push hook (`.claude/hooks/pre_push_lint.py`) runs `ruff check .` plus the 4 platform-independent test files on `git push`; PLECS XML-RPC tests run manually on Windows.
+**No GitHub Actions CI.** A Claude Code pre-push hook (`.claude/hooks/pre_push_lint.py`) runs `ruff check .` plus the 5 platform-independent test files on `git push`; PLECS XML-RPC tests run manually on Windows.
 
 ## Architecture quick reference
 - **Two layers** (full detail in [architecture.md](docs/architecture.md)): `pyplecs/pyplecs.py` is a thin XML-RPC wrapper over PLECS; the orchestration / cache / api / webgui packages are built on top.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,18 @@
 
 ## Build & Test
 ```bash
-pip install -e ".[dev]"
-pytest
-ruff check .
+pip install -e ".[dev]"        # ruff + pytest
+ruff check .                   # lint (must be clean)
+pytest                         # full suite (Windows + PLECS on port 1080)
+pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py  # platform-independent subset
 ```
 
-CI runs only platform-independent tests on Ubuntu. PLECS XML-RPC tests require a running PLECS instance (Windows).
+**No GitHub Actions CI.** A Claude Code pre-push hook (`.claude/hooks/pre_push_lint.py`) runs `ruff check .` plus the 4 platform-independent test files on `git push`; PLECS XML-RPC tests run manually on Windows.
+
+## Architecture quick reference
+- **Two layers** (full detail in [architecture.md](docs/architecture.md)): `pyplecs/pyplecs.py` is a thin XML-RPC wrapper over PLECS; the orchestration / cache / api / webgui packages are built on top.
+- **Tool-agnostic ABCs at `pyplecs.contracts`** — public façade that prefers an installed PyPI `pycircuitsim_core` (when major-version-compatible) and falls back to the vendored copy at `pyplecs/_contracts/`. **Hard rule:** PyPLECS is standalone — never add `pycircuitsim-core` to `pyproject.toml` dependencies. See `tools/SYNC_PYCIRCUITSIM_CORE.md` for re-sync procedure.
+- **Optional deps degrade to `None`** — `pyplecs/__init__.py` sets `PlecsServer`, `create_api_app`, `create_web_app`, etc. to `None` when their optional packages aren't installed; callers must handle `None`.
 
 ## Key Documents
 - [PRD](docs/prd.md) — requirements and roadmap
@@ -17,27 +23,24 @@ CI runs only platform-independent tests on Ubuntu. PLECS XML-RPC tests require a
 - [Auto-Context](docs/auto-context.md) — generated project summary
 - [API](docs/api.md) — REST API reference
 - [Install](docs/install.md) — installation and configuration
-- [Changelog](docs/changelog.md) — version history
-- [Web GUI](docs/webgui.md) — dashboard guide
-- [Contributing](docs/contributing.md) — development workflow
 - [Migration](docs/migration.md) — v0.x to v1.0.0 upgrade
+- [Contributing](docs/contributing.md) — development workflow
 
-## Sprint Plans
-Convention: `docs/sprints/sprint-*.md` | Default model: **sonnet**
+## Specs & Plans
+- Specs: `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- Plans: `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`
+- Sprint plans (legacy): `docs/sprints/sprint-*.md`
+- Default execution model: **sonnet**
 
 ## Skills
-Central pool (WSL): `\\wsl$\Ubuntu\home\tinix\claude_wsl\agents_pool\`
-```bash
-python -m src.cli list           # List all skills
-python -m src.cli run sw-arch .  # Run architecture analysis
-```
-Domain: pe-expert | Local skills reference: `.claude/skills.md`
+Local skills reference: [`.claude/skills.md`](.claude/skills.md) — canonical command sequences (ruff, pytest, entry points, code patterns).
+Central pool (WSL): `\\wsl$\Ubuntu\home\tinix\claude_wsl\agents_pool\` | Domain: pe-expert.
 
 ## Task Protocol
 1. **90% Rule**: Ask clarifying questions until task is >= 90% clear
-2. Complex tasks -> sprint plan in `docs/sprints/` -> execute with sonnet
-3. Run tests after changes: `pytest`
-4. On commit: update CLAUDE.md, prd.md, architecture.md if behavior changed
+2. Multi-step tasks -> spec in `docs/superpowers/specs/` -> plan in `docs/superpowers/plans/` -> execute with sonnet (use the superpowers skills)
+3. Run tests after changes: `ruff check . && pytest`
+4. On commit: update CLAUDE.md, prd.md, architecture.md if behavior changed; new architectural decisions go in the Decision Log below
 
 ## Decision Log
 | Date | Decision | Rationale |
@@ -48,3 +51,6 @@ Domain: pe-expert | Local skills reference: `.claude/skills.md`
 | 2026-02-24 | All doc filenames lowercase | URL-friendly mkdocs output; consistent across projects |
 | 2026-02-24 | mkdocs gh-deploy to GitHub Pages | Public docs at tinix84.github.io/pyplecs |
 | 2026-04-25 | Remove GitHub Actions CI | Single-maintainer project; pre-push hook covers lint + platform-independent tests; PLECS-dependent tests run manually on Windows. |
+| 2026-04-25 | Vendor `pycircuitsim_core` ABCs at `pyplecs/_contracts/`, expose via `pyplecs.contracts` façade with PyPI passthrough | PyPLECS must work standalone (no transitive dep on `pycircuitsim-core`); umbrella PyCircuitSim ecosystem is auto-detected when present. Vendored copy stays forever; no exit clause. |
+| 2026-04-25 | Move `articles/` under `docs/articles/` | Ship long-form posts via mkdocs to GitHub Pages instead of bloating repo root. |
+| 2026-04-25 | Unify lint on ruff (drop black/flake8/mypy/isort) | Single tool covers format + lint + isort; one config in `pyproject.toml`. |

--- a/docs/auto-context.md
+++ b/docs/auto-context.md
@@ -1,33 +1,62 @@
 # PyPLECS — Auto-Context
 
-> Auto-generated project summary. Last updated: 2026-02-24.
+> Auto-generated project summary. Last updated: 2026-04-26.
 
 ## Project Type
 
-Python package (v1.0.0) — PLECS power electronics simulation automation framework.
+Python package (v1.0.0) — PLECS power electronics simulation automation framework. Standalone-installable; no transitive dependency on the umbrella `pycircuitsim-core` package.
 
 ## Package Structure
 
 ```
 pyplecs/
-├── __init__.py              # Package exports: PlecsServer, SimulationOrchestrator, etc.
+├── __init__.py              # Public exports: PlecsServer, SimulationOrchestrator,
+│                            # SimulationCache, SimulationRequest, SimulationResult,
+│                            # TaskPriority, get_config, get_logger, etc.
 ├── pyplecs.py               # Core XML-RPC wrapper (PlecsServer, PlecsApp)
+├── contracts.py             # Public façade for shared simulation ABCs.
+│                            # Prefers external pycircuitsim_core when installed
+│                            # AND major-version-compatible; falls back to vendored
+│                            # copy below. Reports source via _source attribute.
+├── _contracts/              # Vendored copy of pycircuitsim_core ABCs.
+│   ├── __init__.py          # Exports SimulationServer, SimulationCacheBase, etc.
+│   │                        # Pinned to tinix84/pycircuitsim@<sha> (header in each
+│   │                        # file). __contract_version__ = "1.0".
+│   ├── server.py            # SimulationServer ABC
+│   ├── cache.py             # SimulationCacheBase ABC + compute_hash helper
+│   ├── config.py            # ConfigManagerBase ABC + shared config dataclasses
+│   ├── logging.py           # StructuredLoggerBase ABC
+│   ├── orchestration.py     # SimulationOrchestratorBase ABC
+│   └── models.py            # Pydantic SimulationRequest, SimulationResult,
+│                            # SimulationStatus, TaskPriority, SyncSimulationRequest,
+│                            # SyncSimulationResponse
 ├── config.py                # YAML config management (search hierarchy)
 ├── core/
-│   └── models.py            # Pydantic models (SimulationRequest, SimulationResult)
+│   └── models.py            # pyplecs-local dataclass models (SimulationRequest,
+│                            # SimulationResult, ComponentParameter, OptimizationRequest,
+│                            # OptimizationResult). Distinct namespace from
+│                            # pycircuitsim_core.models — see spec for rationale.
 ├── orchestration/
-│   └── __init__.py          # Priority queue, batch execution, retry logic
+│   └── __init__.py          # SimulationOrchestrator: priority queue, batch
+│                            # execution, retry logic. Inherits SimulationOrchestratorBase.
 ├── cache/
-│   └── __init__.py          # SHA256 hash-based result caching (Parquet/HDF5/CSV)
+│   └── __init__.py          # SimulationCache: SHA256-keyed result caching
+│                            # (Parquet/HDF5/CSV). Inherits SimulationCacheBase.
 ├── api/
-│   └── __init__.py          # FastAPI REST endpoints (create_api_app)
+│   ├── __init__.py          # FastAPI REST endpoints (create_api_app)
+│   └── simulation_sync.py   # Sync simulation endpoint
 ├── webgui/
-│   └── webgui.py            # Flask/Starlette dashboard with WebSocket updates
+│   ├── __init__.py
+│   ├── webgui.py            # Flask/Starlette dashboard with WebSocket updates
+│   ├── static/
+│   └── templates/
 ├── cli/
+│   ├── __init__.py
 │   └── installer.py         # Setup wizard (pyplecs-setup)
-├── mcp/                     # Model Context Protocol server (planned)
-├── optimizer/               # Optimization algorithms
-└── logging/                 # Structured logging
+├── mcp/                     # Model Context Protocol server (planned, gracefully degraded)
+├── optimizer/               # Optimization algorithms (planned, gracefully degraded)
+└── logging/
+    └── __init__.py          # StructuredLogger inheriting StructuredLoggerBase
 ```
 
 ## Entry Points
@@ -41,44 +70,64 @@ pyplecs/
 
 ## Dependencies
 
-- **Runtime**: xmlrpc (stdlib), pydantic, fastapi, uvicorn, flask, pyyaml, pandas, pyarrow
-- **Windows-only**: pywinauto (GUI automation), psutil (process priority)
-- **Dev**: pytest, black, isort, flake8, mypy
+- **Runtime** (`pyproject.toml` `[project].dependencies`): numpy, scipy, pandas, pyyaml, pydantic>=2.0, structlog>=21.1.0, click>=8.0.0, python-dotenv>=0.19.0, packaging>=21.0. **No `pycircuitsim-core`** — the ABC layer is vendored at `pyplecs/_contracts/`.
+- **Optional `[web]` extras**: fastapi, uvicorn, jinja2, aiofiles, websockets, python-multipart, plotly, rich, tqdm.
+- **Windows-only (not declared)**: pywinauto (GUI automation via `PlecsApp`), psutil (process priority). Missing → public `PlecsServer`/`PlecsApp` exports become `None`.
+- **Dev** (`requirements-dev.txt`): pytest, pytest-asyncio, pytest-cov, **ruff** (single tool for lint + format), mkdocs, mkdocs-material.
 
 ## Configuration
 
 - Default config: `config/default.yml`
-- Search order: cwd -> parent dirs (3 levels) -> package dir -> `~/.pyplecs/config.yml`
-- Key settings: PLECS path, XML-RPC port (1080), cache backend, concurrency (4)
+- Search order (in `pyplecs/config.py`): cwd → parent dirs (3 levels up) → package dir → `~/.pyplecs/config.yml` → `/etc/pyplecs/config.yml`.
+- Key settings: PLECS executable path, XML-RPC port (1080), cache backend (file/Redis/memory), max concurrent simulations (4).
 
 ## Test Structure
 
 ```
 tests/
-├── test_basic.py                      # Legacy automation tests
-├── test_plecs_server_refactored.py    # Core API tests
-├── test_orchestrator_batch.py         # Orchestration tests
-├── test_refactored.py                 # Modern architecture
-├── test_webgui.py                     # Web GUI tests
-├── test_installer.py                  # Setup wizard (CI-safe)
-├── test_entrypoint.py                 # Entry points (CI-safe)
-├── test_install_full.py               # Full installation (CI-safe)
-└── benchmark_batch_speedup.py         # Performance benchmarks
+├── test_abc_contract.py             # ABC compliance — runs without PLECS
+├── test_installer.py                # Setup wizard (no PLECS)
+├── test_entrypoint.py               # Entry points (no PLECS)
+├── test_install_full.py             # Full installation (no PLECS)
+├── test_basic.py                    # Legacy automation (Windows + PLECS)
+├── test_plecs_server_refactored.py  # Core API (Windows + PLECS)
+├── test_orchestrator_batch.py       # Orchestration (Windows + PLECS)
+├── test_refactored.py               # Modern architecture (Windows + PLECS)
+├── test_webgui.py                   # Web GUI (Windows + PLECS)
+└── benchmark_batch_speedup.py       # Performance benchmarks
 ```
 
-CI runs only platform-independent tests (installer, entrypoint, install_full) on Ubuntu.
-PLECS XML-RPC tests require a running PLECS instance on Windows.
+**Pre-push enforcement** (`.claude/hooks/pre_push_lint.py`): runs `ruff check .` + the 4 platform-independent test files (`test_installer.py`, `test_entrypoint.py`, `test_install_full.py`, `test_abc_contract.py`) on `git push`. No GitHub Actions CI.
+
+## Public Façade for Tool-Agnostic Contracts
+
+`pyplecs.contracts` is the stable public namespace for shared simulation ABCs and pydantic models. Resolution order:
+
+1. PyPI `pycircuitsim_core` if importable AND major-version-compatible (`__contract_version__` or `__version__` major matches `1`).
+2. Vendored `pyplecs._contracts` (always works, ships with pyplecs).
+
+`contracts._source` reports `"pypi"` or `"vendored"`. If a partial PyPI install is detected (importable but missing names), the shim falls back to vendored automatically.
+
+Re-sync procedure for the vendored copy: `tools/SYNC_PYCIRCUITSIM_CORE.md`.
+
+## Documentation
+
+- Static site: built via `mkdocs build`, deployed to https://tinix84.github.io/pyplecs/.
+- Articles (LinkedIn, Substack, diagrams) live at `docs/articles/` so they ship with the site.
+- Specs: `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
+- Plans: `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`.
 
 ## Integration Context
 
-- **Upstream**: NTBEES2 sends TAS (Topology Agnostic Structure) JSON
-- **Downstream**: PLECS via XML-RPC on port 1080
-- **Siblings**: PyMKF (magnetics), PyGecko (open-source sim, planned)
+- **Upstream**: NTBEES2 sends TAS (Topology Agnostic Structure) JSON.
+- **Downstream**: PLECS via XML-RPC on port 1080.
+- **Sibling tools** (planned via shared `pycircuitsim_core` ABC contract): PyMKF (magnetics), PyGeckoCircuit (open-source sim).
+- **Umbrella**: `tinix84/pycircuitsim` monorepo coordinates the shared ABC contract; PyPLECS stays standalone-installable.
 
 ## Key Metrics
 
 | Metric | Value |
 |--------|-------|
-| Batch speedup | 3-5x (vs sequential) |
-| Cache speedup | 100-1000x (repeated simulations) |
+| Batch speedup | 3–5x (vs sequential, via PLECS native parallel API) |
+| Cache speedup | 100–1000x (repeated simulations) |
 | Concurrency | 4 parallel simulations (configurable) |

--- a/docs/auto-context.md
+++ b/docs/auto-context.md
@@ -53,7 +53,7 @@ pyplecs/
 ├── cli/
 │   ├── __init__.py
 │   └── installer.py         # Setup wizard (pyplecs-setup)
-├── mcp/                     # Model Context Protocol server (planned, gracefully degraded)
+├── mcp/                     # Stdio MCP server backing the plecs-expert skill (gracefully degraded if `mcp` extra not installed)
 ├── optimizer/               # Optimization algorithms (planned, gracefully degraded)
 └── logging/
     └── __init__.py          # StructuredLogger inheriting StructuredLoggerBase
@@ -66,7 +66,7 @@ pyplecs/
 | `pyplecs-setup` | `pyplecs.cli.installer:main` | Setup wizard |
 | `pyplecs-gui` | `pyplecs.webgui:run_app` | Web dashboard |
 | `pyplecs-api` | `pyplecs.api:main` | REST API server |
-| `pyplecs-mcp` | `pyplecs.mcp:main` | MCP server (planned) |
+| `pyplecs-mcp` | `pyplecs.mcp:main` | Stdio MCP server exposing the `plecs-expert` skill (8 read-only tools) |
 
 ## Dependencies
 

--- a/docs/superpowers/plans/2026-04-27-plecs-expert-skill.md
+++ b/docs/superpowers/plans/2026-04-27-plecs-expert-skill.md
@@ -1138,20 +1138,32 @@ Topics not covered offline. Skill should `WebFetch` the URL, summarize in cavema
 | `references/url-index.md` | n/a (URL list only) | n/a | URL pointers (no Plexim prose mirrored) |
 ```
 
-- [ ] **Step 3: Run all tests**
+- [ ] **Step 3: Remove vacuous-pass guards from `tests/test_plecs_expert.py`**
+
+By the end of Task 18, `references/` is fully populated. The three early-return guards introduced in Task 1 must now be removed so the tests start enforcing.
+
+In `tests/test_plecs_expert.py`, delete:
+- `if not root.exists(): return  # phase 1 vacuous pass` from `test_references_no_dead_links`
+- `if not refs.exists() or not notes.exists(): return  # phase 1 vacuous pass` from `test_license_notes_complete`
+- `if not idx.exists(): return  # phase 1 vacuous pass` from `test_url_index_resolvable`
+
+If a guard's removal would make a test fail, that's the point — fix the underlying gap (missing file, dead link, missing license-notes row) before committing.
+
+- [ ] **Step 4: Run all tests**
 
 ```bash
 pytest tests/test_plecs_expert.py -v
 ```
 
-Expected: pass; `test_url_index_resolvable` now scans real URLs.
+Expected: pass; `test_url_index_resolvable` now scans real URLs; the other two tests are now actively enforcing.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add .claude/skills/plecs-expert/references/url-index.md \
-        .claude/skills/plecs-expert/LICENSE-NOTES.md
-git commit -m "feat(skill): url-index.md fallback table"
+        .claude/skills/plecs-expert/LICENSE-NOTES.md \
+        tests/test_plecs_expert.py
+git commit -m "feat(skill): url-index.md + drop vacuous-pass guards"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-27-plecs-expert-skill.md
+++ b/docs/superpowers/plans/2026-04-27-plecs-expert-skill.md
@@ -1,0 +1,1724 @@
+# PLECS-Expert Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `plecs-expert` skill (Claude Code skill + `/plecs` slash command + stdio MCP server) backed by an offline reference of PLECS docs (verbatim factual tables + caveman-style rewritten prose) and live introspection of `pyplecs` modules.
+
+**Architecture:** Single source of truth at `pyplecs/.claude/skills/plecs-expert/references/` is consumed three ways: by Claude Code via the `Skill` tool, by `/plecs` via a slash command stub, and by external AI clients via `pyplecs-mcp` over stdio. MCP tools compose answers from the offline reference (Layer A) and live `pyplecs` introspection (Layer B), preferring the wrapped/typed source when both are available.
+
+**Tech Stack:** Python 3.8+ (project floor), `mcp` SDK (stdio transport), `httpx` for refresh-tooling scrapes, `BeautifulSoup4` for HTML parsing in `sync_tables.py`. `ruff` for lint; `pytest` for tests. No new runtime dependencies for `pyplecs-mcp` itself beyond `mcp`.
+
+**Branch:** `feature/plecs-expert-skill` (already created; spec at `093657b`).
+
+**Spec reference:** [`docs/superpowers/specs/2026-04-27-plecs-expert-skill-design.md`](../specs/2026-04-27-plecs-expert-skill-design.md).
+
+---
+
+## File Structure
+
+| File | Purpose | Phase |
+|------|---------|-------|
+| `pyplecs/.claude/skills/plecs-expert/SKILL.md` | Frontmatter + body (≤ 4 KB), routing + composition rules | 1 |
+| `pyplecs/.claude/skills/plecs-expert/style/caveman.md` | Style rules + banned-words list (test data source) | 1 |
+| `pyplecs/.claude/skills/plecs-expert/LICENSE-NOTES.md` | Per-file verbatim/rewritten classification | 1 |
+| `pyplecs/.claude/skills/plecs-expert/manifest.json` | Source URL → content hash table | 2 |
+| `pyplecs/.claude/skills/plecs-expert/tools/sync_tables.py` | Scrape + extract verbatim tables | 2 |
+| `pyplecs/.claude/skills/plecs-expert/tools/check_drift.py` | Diff manifest hashes + introspection diff | 2 |
+| `pyplecs/.claude/skills/plecs-expert/tools/REFRESH.md` | Human refresh procedure | 2 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/electrical-passive.md` | R, L, C, mutual-L, transformer | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/electrical-sources.md` | V, I sources, signal sources | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/electrical-switches.md` | MOSFET, IGBT, diode, ideal switch | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/electrical-meters.md` | Voltmeter, ammeter, scope, probe | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/magnetic.md` | Permeance, MMF source, flux meter | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/thermal.md` | Heat sink, thermal capacitor, thermal probe | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/control.md` | PI, PID, transfer fn, state machine | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/components/system.md` | Subsystem, configurable subsystem, mask | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/rpc-api.md` | XML-RPC function table | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/plecs-xml-grammar.md` | `.plecs` schematic XML grammar | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/solver.md` | Solver types, params, tolerances | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/codegen.md` | PLECS Coder, target hooks | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/cscript.md` | C-Script block API | 4 |
+| `pyplecs/.claude/skills/plecs-expert/references/url-index.md` | Topic → docs.plexim.com URL fallback | 5 |
+| `pyplecs/.claude/commands/plecs.md` | `/plecs` slash command stub | 6 |
+| `pyplecs/pyplecs/mcp/server.py` | MCP stdio server boilerplate | 7 |
+| `pyplecs/pyplecs/mcp/plecs_tools.py` | 8 read-only MCP tool implementations | 7 |
+| `pyplecs/pyplecs/mcp/__init__.py` | Wires `create_mcp_server` + `main`; entry point target | 7 |
+| `pyplecs/pyproject.toml` | Add `pyplecs-mcp` script + `mcp` extra | 7 |
+| `pyplecs/tests/test_plecs_expert.py` | 8 tests per spec | 1, 6, 7 |
+| `pyplecs/.claude/hooks/pre_push_lint.py` | Add `tests/test_plecs_expert.py` to platform-independent set | 1 |
+
+---
+
+## Phase 1 — Test infrastructure + skill skeleton
+
+### Task 1: Create skill skeleton + size-budget test
+
+**Files:**
+- Create: `pyplecs/.claude/skills/plecs-expert/SKILL.md`
+- Create: `pyplecs/.claude/skills/plecs-expert/style/caveman.md` (placeholder)
+- Create: `pyplecs/.claude/skills/plecs-expert/LICENSE-NOTES.md` (placeholder)
+- Create: `pyplecs/.claude/skills/plecs-expert/references/.gitkeep`
+- Create: `pyplecs/.claude/skills/plecs-expert/references/components/.gitkeep`
+- Create: `pyplecs/tests/test_plecs_expert.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`pyplecs/tests/test_plecs_expert.py`:
+```python
+"""Tests for the plecs-expert skill (file layout, content, MCP wiring).
+
+Platform-independent: no PLECS instance, no network, no subprocess.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).parent.parent / ".claude" / "skills" / "plecs-expert"
+
+
+def test_skill_md_under_4kb():
+    """SKILL.md body must be lookup-fast; cap at 4 KB."""
+    skill_md = SKILL_ROOT / "SKILL.md"
+    assert skill_md.exists(), f"missing: {skill_md}"
+    size = skill_md.stat().st_size
+    assert size <= 4096, f"SKILL.md is {size} bytes (limit 4096)"
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```bash
+pytest tests/test_plecs_expert.py::test_skill_md_under_4kb -v
+```
+
+Expected: `FAILED` with `AssertionError: missing: ...SKILL.md`.
+
+- [ ] **Step 3: Write SKILL.md (minimal compliant body)**
+
+`pyplecs/.claude/skills/plecs-expert/SKILL.md`:
+```markdown
+---
+name: plecs-expert
+description: PLECS authoring help, .plecs schematic format, XML-RPC API, and SPICE-mapping reference. Use when answering "how do I X in PLECS", working on the netlist converter, or extending the PlecsServer XML-RPC wrapper.
+allowed-tools: Read, Grep, Glob, WebFetch, Bash
+---
+
+# PLECS Expert
+
+Lookup-first PLECS reference grounded in docs.plexim.com. Two layers:
+
+- **Layer A — offline docs**: `references/`. Verbatim factual tables + caveman prose.
+- **Layer B — pyplecs code**: `pyplecs.plecs_components`, `pyplecs.pyplecs.PlecsServer`. Live introspection.
+
+## Routing
+
+| Topic | File |
+|-------|------|
+| Electrical passives (R, L, C, transformer) | `references/components/electrical-passive.md` |
+| Sources (V, I, signal) | `references/components/electrical-sources.md` |
+| Switches (MOSFET, IGBT, diode) | `references/components/electrical-switches.md` |
+| Meters & scopes | `references/components/electrical-meters.md` |
+| Magnetic blocks | `references/components/magnetic.md` |
+| Thermal blocks | `references/components/thermal.md` |
+| Control library | `references/components/control.md` |
+| Subsystems & masks | `references/components/system.md` |
+| XML-RPC API | `references/rpc-api.md` |
+| `.plecs` XML grammar | `references/plecs-xml-grammar.md` |
+| Solver | `references/solver.md` |
+| Codegen (PLECS Coder) | `references/codegen.md` |
+| C-Script block | `references/cscript.md` |
+| Long-tail topics | `references/url-index.md` (then WebFetch the listed URL) |
+
+## Composition rule
+
+For component or RPC questions, check Layer B first. If a `*PlecsMdl` class exists in `pyplecs.plecs_components`, cite the wrapper. If a method exists on `PlecsServer`, cite it. Else cite Layer A. Else WebFetch from `references/url-index.md`.
+
+## Citation rule
+
+Every answer cites a `references/*` path or a `docs.plexim.com` URL. No ungrounded claims.
+
+## Style
+
+Generated prose follows `style/caveman.md`: fragments OK, drop articles/hedging/filler, pattern `[thing] [action] [reason]. [next step].`.
+
+## Boundary
+
+This skill does not cover: PLECS RT Box (separate future skill), license/purchasing, third-party libraries.
+```
+
+- [ ] **Step 4: Add second test — references_no_dead_links walker (vacuously passes)**
+
+Append to `pyplecs/tests/test_plecs_expert.py`:
+```python
+import re
+
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def _walk_md(root: Path):
+    return sorted(p for p in root.rglob("*.md"))
+
+
+def test_references_no_dead_links():
+    """Every relative link in references/*.md resolves to an existing file."""
+    root = SKILL_ROOT / "references"
+    if not root.exists():
+        return  # phase 1 vacuous pass
+    failures: list[str] = []
+    for md in _walk_md(root):
+        text = md.read_text(encoding="utf-8")
+        for target in MD_LINK_RE.findall(text):
+            if target.startswith(("http://", "https://", "#")):
+                continue
+            target_path = (md.parent / target.split("#", 1)[0]).resolve()
+            if not target_path.exists():
+                failures.append(f"{md}: dead link → {target}")
+    assert not failures, "\n".join(failures)
+```
+
+- [ ] **Step 5: Add third test — license_notes_complete (vacuously passes)**
+
+Append:
+```python
+def test_license_notes_complete():
+    """Every references/*.md is classified in LICENSE-NOTES.md."""
+    notes = SKILL_ROOT / "LICENSE-NOTES.md"
+    refs = SKILL_ROOT / "references"
+    if not refs.exists() or not notes.exists():
+        return  # phase 1 vacuous pass
+    notes_text = notes.read_text(encoding="utf-8")
+    failures: list[str] = []
+    for md in _walk_md(refs):
+        rel = md.relative_to(SKILL_ROOT).as_posix()
+        if rel not in notes_text:
+            failures.append(f"{rel} not listed in LICENSE-NOTES.md")
+    assert not failures, "\n".join(failures)
+```
+
+- [ ] **Step 6: Add fourth test — url_index_resolvable (vacuously passes)**
+
+Append:
+```python
+URL_RE = re.compile(r"https?://[^\s)>\]]+")
+
+
+def test_url_index_resolvable():
+    """URLs in url-index.md are syntactically valid (no fetch)."""
+    idx = SKILL_ROOT / "references" / "url-index.md"
+    if not idx.exists():
+        return  # phase 1 vacuous pass
+    failures: list[str] = []
+    for url in URL_RE.findall(idx.read_text(encoding="utf-8")):
+        if "docs.plexim.com" not in url:
+            continue
+        if " " in url or url.endswith((".",  ",", ";")):
+            failures.append(f"malformed URL: {url}")
+    assert not failures, "\n".join(failures)
+```
+
+- [ ] **Step 7: Write minimal LICENSE-NOTES.md and caveman.md placeholders**
+
+`pyplecs/.claude/skills/plecs-expert/LICENSE-NOTES.md`:
+```markdown
+# License Notes
+
+`docs.plexim.com` content is Plexim's proprietary documentation. This skill mirrors only **factual tables** verbatim (parameter names, defaults, units, RPC signatures, XML element grammar — facts not copyrightable) and rewrites all **prose** in our own caveman-style words.
+
+| File | Source URL | Verbatim sections | Rewritten sections |
+|------|-----------|-------------------|---------------------|
+```
+
+`pyplecs/.claude/skills/plecs-expert/style/caveman.md`:
+```markdown
+# Caveman Style (placeholder — populated in Task 2)
+
+See https://github.com/juliusbrussee/caveman.
+```
+
+- [ ] **Step 8: Run all four tests, confirm they pass**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: 4 passed. The dead-links / license-notes / url-index tests pass vacuously because `references/` is empty.
+
+- [ ] **Step 9: Add `tests/test_plecs_expert.py` to the pre-push hook's platform-independent set**
+
+In `.claude/hooks/pre_push_lint.py`, modify the `PYTEST_FILES` list:
+```python
+PYTEST_FILES = [
+    "tests/test_installer.py",
+    "tests/test_entrypoint.py",
+    "tests/test_install_full.py",
+    "tests/test_abc_contract.py",
+    "tests/test_plecs_expert.py",
+]
+```
+
+Also update `CLAUDE.md`'s "Build & Test" block to include the new file in the platform-independent subset command:
+```bash
+pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py tests/test_plecs_expert.py
+```
+
+- [ ] **Step 10: Run ruff and the full subset to confirm clean**
+
+```bash
+ruff check .
+pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py tests/test_plecs_expert.py
+```
+
+Expected: both green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/SKILL.md \
+        .claude/skills/plecs-expert/style/caveman.md \
+        .claude/skills/plecs-expert/LICENSE-NOTES.md \
+        .claude/skills/plecs-expert/references \
+        tests/test_plecs_expert.py \
+        .claude/hooks/pre_push_lint.py \
+        CLAUDE.md
+git commit -m "feat(skill): bootstrap plecs-expert skill skeleton + tests"
+```
+
+---
+
+### Task 2: Style rules — `caveman.md` + compliance test
+
+**Files:**
+- Modify: `pyplecs/.claude/skills/plecs-expert/style/caveman.md`
+- Modify: `pyplecs/tests/test_plecs_expert.py` (add `test_caveman_compliance`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pyplecs/tests/test_plecs_expert.py`:
+```python
+BANNED_WORDS = {
+    # caveman methodology — drop articles, fillers, hedging.
+    # We can't strip articles globally without false positives, so the
+    # banned set is just fillers + hedges. See style/caveman.md.
+    "basically",
+    "really",
+    "actually",
+    "essentially",
+    "obviously",
+    "simply",
+    "just",     # ambiguous in code contexts; allow override via marker
+    "very",
+    "quite",
+    "perhaps",
+    "maybe",
+}
+
+ALLOW_MARKER = "<!-- caveman:allow -->"
+
+
+def _strip_code_blocks(text: str) -> str:
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+def test_caveman_compliance():
+    """Rewritten prose in references/*.md must avoid banned filler words."""
+    refs = SKILL_ROOT / "references"
+    if not refs.exists():
+        return
+    failures: list[str] = []
+    for md in _walk_md(refs):
+        text = md.read_text(encoding="utf-8")
+        if ALLOW_MARKER in text:
+            continue
+        prose = _strip_code_blocks(text)
+        for line_no, line in enumerate(prose.splitlines(), start=1):
+            tokens = re.findall(r"\b\w+\b", line.lower())
+            for word in BANNED_WORDS:
+                if word in tokens:
+                    failures.append(f"{md.relative_to(SKILL_ROOT)}:{line_no} banned: {word}")
+    assert not failures, "\n".join(failures)
+```
+
+- [ ] **Step 2: Run test, confirm it passes (vacuously, references/ still empty)**
+
+```bash
+pytest tests/test_plecs_expert.py::test_caveman_compliance -v
+```
+
+Expected: PASS (no files to scan).
+
+- [ ] **Step 3: Write the real `caveman.md`**
+
+Replace `pyplecs/.claude/skills/plecs-expert/style/caveman.md`:
+```markdown
+# Caveman Style — Prose Rules for plecs-expert
+
+Reference: https://github.com/juliusbrussee/caveman
+
+## Core rule
+
+Drop: articles, filler, hedging, pleasantries.
+Fragments OK.
+Pattern: `[thing] [action] [reason]. [next step].`
+Code blocks: never modified — kept exactly as authored.
+
+## Banned words (enforced by `tests/test_plecs_expert.py::test_caveman_compliance`)
+
+`basically`, `really`, `actually`, `essentially`, `obviously`, `simply`, `just`, `very`, `quite`, `perhaps`, `maybe`.
+
+## Allow marker
+
+If a banned word is unavoidable (rare), include the literal marker `<!-- caveman:allow -->` anywhere in the file. The whole file is then exempt. Use sparingly; comment why.
+
+## Examples
+
+**Bad:**
+> The Inductor block is basically just a passive component that really stores energy in a magnetic field. You can simply set its initial current via the IL_init parameter.
+
+**Good (caveman):**
+> Inductor block. Passive. Stores energy in magnetic field. Param `IL_init` sets initial current.
+
+**Bad:**
+> Note that the MOSFET model is actually quite detailed and includes both conduction and switching losses if you configure it properly.
+
+**Good (caveman):**
+> MOSFET model. Conduction + switching loss. Enable via `model_level=2`.
+
+## What's verbatim, what's rewritten
+
+| Section type | Posture |
+|--------------|---------|
+| Parameter tables | Verbatim (facts) |
+| RPC function signatures | Verbatim (facts) |
+| XML element grammar | Verbatim (facts) |
+| Defaults & units | Verbatim (facts) |
+| Explanatory prose | Rewritten in caveman style |
+| Examples (our own) | Caveman style |
+
+## Style guide for tables
+
+Tables are facts. Keep verbatim from docs.plexim.com. Add a `Source:` line below each table pointing to the source URL.
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/style/caveman.md tests/test_plecs_expert.py
+git commit -m "feat(skill): caveman style rules + compliance test"
+```
+
+---
+
+## Phase 2 — Refresh tooling
+
+### Task 3: Manifest schema + initial seed
+
+**Files:**
+- Create: `pyplecs/.claude/skills/plecs-expert/manifest.json`
+
+- [ ] **Step 1: Write `manifest.json` with URL-to-file mapping (no hashes yet)**
+
+`pyplecs/.claude/skills/plecs-expert/manifest.json`:
+```json
+{
+  "plecs_version_pinned": "4.7",
+  "files": {
+    "references/components/electrical-passive.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Resistor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Inductor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Capacitor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Transformer.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-sources.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceAC.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceDC.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/VoltageSourceControlled.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/CurrentSourceControlled.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-switches.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Mosfet.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Igbt.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Diode.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/SwitchIdeal.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/electrical-meters.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Voltmeter.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Electrical/Ammeter.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Scope.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/magnetic.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/Permeance.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/MmfSource.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Magnetic/FluxMeter.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/thermal.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/HeatSink.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/ThermalCapacitor.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Thermal/AmbientTemperature.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/control.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/PIController.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/TransferFunction.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/Control/StateMachine.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/components/system.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Subsystem.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/ConfigurableSubsystem.html",
+        "https://docs.plexim.com/plecs/latest/UserManual/System/Mask.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/rpc-api.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/XmlRpcInterface.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/plecs-xml-grammar.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/PlecsFileFormat.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/solver.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/Simulation/SolverSettings.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/codegen.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/CodeGeneration/Overview.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    },
+    "references/cscript.md": {
+      "source_urls": [
+        "https://docs.plexim.com/plecs/latest/UserManual/CScript.html"
+      ],
+      "table_section_hashes": {},
+      "prose_section_hashes": {}
+    }
+  }
+}
+```
+
+> **Note:** The exact URL slugs above are best-effort guesses against the published doc sitemap. The first run of `sync_tables.py` (Task 4) will surface any 404s — fix the manifest then.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/manifest.json
+git commit -m "feat(skill): add manifest.json with PLECS doc URL mapping"
+```
+
+---
+
+### Task 4: `sync_tables.py` — verbatim factual table extractor
+
+**Files:**
+- Create: `pyplecs/.claude/skills/plecs-expert/tools/sync_tables.py`
+
+- [ ] **Step 1: Write the script**
+
+`pyplecs/.claude/skills/plecs-expert/tools/sync_tables.py`:
+```python
+#!/usr/bin/env python3
+"""Scrape factual tables from PLECS docs into references/*.md.
+
+Reads URLs from manifest.json. For each URL:
+  1. Fetches HTML (httpx).
+  2. Extracts <table> elements (BeautifulSoup).
+  3. Renders each as a Markdown table.
+  4. Writes/updates the verbatim sections of the corresponding references/*.md
+     file, preserving any prose between BEGIN/END markers.
+
+Per-section markers are HTML comments:
+  <!-- BEGIN VERBATIM TABLE: <slug> -->
+  ...table markdown...
+  <!-- END VERBATIM TABLE: <slug> -->
+
+Prose between marker pairs is left untouched. Hashes are written to
+manifest.json so check_drift.py can detect upstream changes.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = SKILL_ROOT / "manifest.json"
+
+BEGIN_RE = re.compile(r"<!--\s*BEGIN VERBATIM TABLE:\s*(?P<slug>[^\s-]+)\s*-->")
+END_RE = re.compile(r"<!--\s*END VERBATIM TABLE:\s*(?P<slug>[^\s-]+)\s*-->")
+
+
+def slugify(url: str) -> str:
+    return Path(url.rstrip("/")).name.replace(".html", "").lower()
+
+
+def html_table_to_markdown(table: Tag) -> str:
+    rows: list[list[str]] = []
+    for tr in table.find_all("tr"):
+        cells = [td.get_text(" ", strip=True) for td in tr.find_all(["td", "th"])]
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    width = max(len(r) for r in rows)
+    rows = [r + [""] * (width - len(r)) for r in rows]
+    out = ["| " + " | ".join(rows[0]) + " |"]
+    out.append("| " + " | ".join(["---"] * width) + " |")
+    for r in rows[1:]:
+        out.append("| " + " | ".join(r) + " |")
+    return "\n".join(out)
+
+
+def fetch(url: str) -> str:
+    resp = httpx.get(url, timeout=30, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.text
+
+
+def extract_tables(html: str, url: str) -> dict[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    tables = soup.find_all("table")
+    base_slug = slugify(url)
+    out: dict[str, str] = {}
+    for i, t in enumerate(tables):
+        md = html_table_to_markdown(t)
+        if md:
+            slug = f"{base_slug}-{i}" if i else base_slug
+            out[slug] = md
+    return out
+
+
+def replace_section(text: str, slug: str, body: str) -> str:
+    begin = f"<!-- BEGIN VERBATIM TABLE: {slug} -->"
+    end = f"<!-- END VERBATIM TABLE: {slug} -->"
+    pattern = re.compile(re.escape(begin) + r".*?" + re.escape(end), re.DOTALL)
+    block = f"{begin}\n\n{body}\n\n{end}"
+    if pattern.search(text):
+        return pattern.sub(block, text)
+    sep = "\n\n" if text and not text.endswith("\n") else "\n"
+    return text + sep + block + "\n"
+
+
+def update_file(target: Path, sections: dict[str, str], source_url: str) -> dict[str, str]:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    text = target.read_text(encoding="utf-8") if target.exists() else f"# {target.stem}\n"
+    hashes: dict[str, str] = {}
+    for slug, body in sections.items():
+        marked = f"{body}\n\n_Source: {source_url}_"
+        text = replace_section(text, slug, marked)
+        hashes[slug] = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    target.write_text(text, encoding="utf-8")
+    return hashes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    for rel_file, entry in manifest["files"].items():
+        target = SKILL_ROOT / rel_file
+        all_hashes: dict[str, str] = {}
+        for url in entry["source_urls"]:
+            try:
+                html = fetch(url)
+            except Exception as exc:
+                failures.append(f"FETCH {url}: {exc}")
+                continue
+            sections = extract_tables(html, url)
+            if not sections:
+                failures.append(f"NO TABLES {url}")
+                continue
+            if args.dry_run:
+                print(f"[dry-run] {rel_file} ← {len(sections)} tables from {url}")
+                continue
+            new_hashes = update_file(target, sections, url)
+            all_hashes.update(new_hashes)
+        if not args.dry_run:
+            entry["table_section_hashes"] = all_hashes
+    if not args.dry_run:
+        MANIFEST_PATH.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Add `httpx` and `beautifulsoup4` to dev extras**
+
+In `pyplecs/pyproject.toml`, locate the `[project.optional-dependencies]` block (or `[project] dependencies` block of `dev` extra). Add to the `dev` extra:
+```toml
+[project.optional-dependencies]
+dev = [
+    # ... existing entries ...
+    "httpx>=0.25",
+    "beautifulsoup4>=4.12",
+]
+```
+
+- [ ] **Step 3: Install + dry-run the script**
+
+```bash
+pip install -e ".[dev]"
+python .claude/skills/plecs-expert/tools/sync_tables.py --dry-run
+```
+
+Expected: prints `[dry-run] ...` lines for every URL. Any FETCH errors mean URLs in `manifest.json` need fixing.
+
+- [ ] **Step 4: Fix any 404s in manifest.json**
+
+If the dry-run reports `FETCH ...: 404`, browse to `https://docs.plexim.com/plecs/latest/` and find the correct page slug. Edit `manifest.json` and re-run dry-run until clean.
+
+- [ ] **Step 5: Run for real (populates table sections in references/*.md)**
+
+```bash
+python .claude/skills/plecs-expert/tools/sync_tables.py
+```
+
+Expected: every `references/*.md` listed in manifest.json now exists with `<!-- BEGIN VERBATIM TABLE: ... -->` blocks populated; `manifest.json` `table_section_hashes` filled in.
+
+- [ ] **Step 6: Update LICENSE-NOTES.md to list every populated file**
+
+Append a row to the table in `LICENSE-NOTES.md` for each file the script just created/touched, using this template (one row per file):
+```markdown
+| `references/components/electrical-passive.md` | https://docs.plexim.com/plecs/latest/UserManual/Electrical/ | tables (verbatim) | prose (caveman, hand-authored) |
+```
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: all pass. The link-checker may flag missing referenced files; if so, fix or remove the dead link.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/manifest.json \
+        .claude/skills/plecs-expert/references \
+        .claude/skills/plecs-expert/tools/sync_tables.py \
+        .claude/skills/plecs-expert/LICENSE-NOTES.md \
+        pyproject.toml
+git commit -m "feat(skill): sync_tables.py + initial verbatim table population"
+```
+
+---
+
+### Task 5: `check_drift.py` — drift detector + REFRESH.md
+
+**Files:**
+- Create: `pyplecs/.claude/skills/plecs-expert/tools/check_drift.py`
+- Create: `pyplecs/.claude/skills/plecs-expert/tools/REFRESH.md`
+
+- [ ] **Step 1: Write `check_drift.py`**
+
+`pyplecs/.claude/skills/plecs-expert/tools/check_drift.py`:
+```python
+#!/usr/bin/env python3
+"""Detect drift between manifest hashes and current docs / pyplecs surface.
+
+Two checks:
+
+1. **Docs drift**: re-fetch each URL in manifest.json, hash extracted tables,
+   compare to stored hashes. Report which references/*.md need a sync.
+
+2. **PyPLECS drift**: introspect `pyplecs.plecs_components` and
+   `pyplecs.pyplecs.PlecsServer`. Diff against the snapshot stored under
+   manifest.json's `pyplecs_snapshot` key. Report wrappers added/removed and
+   RPC methods added/removed.
+
+Output is a Markdown report on stdout. Exit code: 0 if no drift, 1 otherwise.
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import sys
+from pathlib import Path
+
+import httpx
+from bs4 import BeautifulSoup
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = SKILL_ROOT / "manifest.json"
+
+# Reuse extraction logic from sync_tables to keep hashes consistent
+sys.path.insert(0, str(SKILL_ROOT / "tools"))
+from sync_tables import extract_tables, fetch  # noqa: E402
+
+
+def docs_drift(manifest: dict) -> list[str]:
+    issues: list[str] = []
+    for rel_file, entry in manifest["files"].items():
+        stored = entry.get("table_section_hashes", {})
+        for url in entry["source_urls"]:
+            try:
+                html = fetch(url)
+            except Exception as exc:
+                issues.append(f"- FETCH FAILED `{rel_file}` ← {url}: {exc}")
+                continue
+            for slug, body in extract_tables(html, url).items():
+                h = hashlib.sha256(body.encode("utf-8")).hexdigest()
+                if stored.get(slug) != h:
+                    issues.append(f"- DRIFT `{rel_file}` table `{slug}` (source: {url})")
+    return issues
+
+
+def pyplecs_snapshot() -> dict:
+    """Live introspection of pyplecs surface."""
+    import pyplecs.plecs_components as comps
+    from pyplecs.pyplecs import PlecsServer
+
+    wrappers = sorted(
+        n for n, obj in inspect.getmembers(comps, inspect.isclass)
+        if obj.__module__ == comps.__name__
+    )
+    rpc_methods = sorted(
+        n for n, _ in inspect.getmembers(PlecsServer, predicate=inspect.isfunction)
+        if not n.startswith("_")
+    )
+    return {"wrappers": wrappers, "rpc_methods": rpc_methods}
+
+
+def pyplecs_drift(manifest: dict) -> list[str]:
+    current = pyplecs_snapshot()
+    stored = manifest.get("pyplecs_snapshot", {"wrappers": [], "rpc_methods": []})
+    issues: list[str] = []
+    for kind in ("wrappers", "rpc_methods"):
+        added = set(current[kind]) - set(stored[kind])
+        removed = set(stored[kind]) - set(current[kind])
+        for name in sorted(added):
+            issues.append(f"- ADDED {kind}: `{name}` — update `references/` wrapped/not-wrapped status")
+        for name in sorted(removed):
+            issues.append(f"- REMOVED {kind}: `{name}` — was wrapped, now isn't; update references/")
+    return issues
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    docs = docs_drift(manifest)
+    pyp = pyplecs_drift(manifest)
+    print("# Drift Report\n")
+    print("## Docs drift\n")
+    print("\n".join(docs) if docs else "_no docs drift_")
+    print("\n## PyPLECS drift\n")
+    print("\n".join(pyp) if pyp else "_no pyplecs drift_")
+    return 1 if (docs or pyp) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Snapshot current pyplecs surface into manifest.json**
+
+Add a top-level `pyplecs_snapshot` key to `manifest.json`. Generate it by running:
+```bash
+python -c "
+import json, sys
+sys.path.insert(0, '.claude/skills/plecs-expert/tools')
+from check_drift import pyplecs_snapshot
+m = json.load(open('.claude/skills/plecs-expert/manifest.json'))
+m['pyplecs_snapshot'] = pyplecs_snapshot()
+json.dump(m, open('.claude/skills/plecs-expert/manifest.json', 'w'), indent=2)
+print(m['pyplecs_snapshot'])
+"
+```
+
+Expected: prints a dict with `wrappers` (e.g. `MosfetWithDiodePlecsMdl`, `ResistorPlecsMdl`, ...) and `rpc_methods` (`PlecsServer` public methods).
+
+- [ ] **Step 3: Run `check_drift.py` — confirm clean baseline**
+
+```bash
+python .claude/skills/plecs-expert/tools/check_drift.py
+```
+
+Expected: prints `_no docs drift_` and `_no pyplecs drift_`. Exit 0.
+
+- [ ] **Step 4: Write `REFRESH.md`**
+
+`pyplecs/.claude/skills/plecs-expert/tools/REFRESH.md`:
+```markdown
+# Refresh Procedure
+
+Run on every PLECS minor-version bump or quarterly, whichever is sooner.
+
+## 1. Detect drift
+
+```bash
+python .claude/skills/plecs-expert/tools/check_drift.py
+```
+
+Output is a Markdown report. Two sections:
+
+- **Docs drift** — tables changed upstream. `sync_tables.py` will re-fetch.
+- **PyPLECS drift** — wrappers or RPC methods added/removed since last snapshot. Update `references/` wrapped-vs-not-wrapped notes accordingly.
+
+If both sections say "no drift", you're done.
+
+## 2. Re-sync verbatim tables
+
+```bash
+python .claude/skills/plecs-expert/tools/sync_tables.py
+```
+
+Updates `<!-- BEGIN VERBATIM TABLE: ... -->` blocks in place. Prose between blocks untouched.
+
+## 3. Re-author flagged prose
+
+For each `DRIFT` line in step 1's report, open the listed file and re-author the surrounding caveman-style prose. Apply `style/caveman.md`.
+
+For each `ADDED`/`REMOVED` line, update the relevant `references/components/*.md` to flip its "wrapped via `pyplecs.<class>`" / "not wrapped, see SPICE map" notes.
+
+## 4. Update pyplecs snapshot
+
+```bash
+python -c "
+import json, sys
+sys.path.insert(0, '.claude/skills/plecs-expert/tools')
+from check_drift import pyplecs_snapshot
+m = json.load(open('.claude/skills/plecs-expert/manifest.json'))
+m['pyplecs_snapshot'] = pyplecs_snapshot()
+json.dump(m, open('.claude/skills/plecs-expert/manifest.json','w'), indent=2)
+"
+```
+
+## 5. Bump version pin
+
+Edit `manifest.json`'s `plecs_version_pinned` if PLECS minor changed.
+
+## 6. Verify + commit
+
+```bash
+ruff check .
+pytest tests/test_plecs_expert.py
+git add .claude/skills/plecs-expert
+git commit -m "chore(skill): refresh plecs-expert against PLECS X.Y"
+```
+```
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/tools/check_drift.py \
+        .claude/skills/plecs-expert/tools/REFRESH.md \
+        .claude/skills/plecs-expert/manifest.json
+git commit -m "feat(skill): check_drift.py + REFRESH procedure"
+```
+
+---
+
+## Phase 3 — Hand-author caveman prose
+
+> **Scope reminder:** Tasks 6–17 each follow the same template. The first one (Task 6 below) shows the full template. Tasks 7–17 list only file paths, source URLs, and content-specific notes — the steps are identical otherwise.
+
+### Task 6: Author prose for `electrical-passive.md`
+
+**Files:**
+- Modify: `pyplecs/.claude/skills/plecs-expert/references/components/electrical-passive.md`
+- Modify: `pyplecs/.claude/skills/plecs-expert/LICENSE-NOTES.md` (already has the row from Task 4 — verify)
+
+**Source URLs (already in manifest):**
+- https://docs.plexim.com/plecs/latest/UserManual/Electrical/Resistor.html
+- https://docs.plexim.com/plecs/latest/UserManual/Electrical/Inductor.html
+- https://docs.plexim.com/plecs/latest/UserManual/Electrical/Capacitor.html
+- https://docs.plexim.com/plecs/latest/UserManual/Electrical/Transformer.html
+
+- [ ] **Step 1: Read the populated file**
+
+```bash
+cat .claude/skills/plecs-expert/references/components/electrical-passive.md
+```
+
+You'll see one or more `<!-- BEGIN VERBATIM TABLE: ... -->` blocks (parameters, defaults, units). Prose sections between/around them are empty or stubby — that's what you re-author.
+
+- [ ] **Step 2: For each component, write a caveman-style prose section ABOVE its verbatim table**
+
+Template (apply to every component):
+```markdown
+## <ComponentName>
+
+`Lib/Electrical/Passive`. <one-sentence purpose>. Pins: <p, n, ...>. Sign convention: <e.g., i flows p→n>.
+
+Wrapped in pyplecs: <yes — `pyplecs.plecs_components.<ClassName>` | no>.
+
+SPICE map: <e.g., `R<name> p n {R}` | n/a>.
+
+<!-- BEGIN VERBATIM TABLE: ... -->
+... (left untouched by sync_tables.py) ...
+<!-- END VERBATIM TABLE: ... -->
+
+### Notes
+- <fact 1: terse, caveman style, factual>.
+- <fact 2>.
+```
+
+Example — Inductor section:
+```markdown
+## Inductor
+
+`Lib/Electrical/Passive`. Stores magnetic energy. Pins: 1=p, 2=n. Sign: i_L flows p→n.
+
+Wrapped in pyplecs: no (use raw RPC `set("Inductor1/L", "1e-3")`).
+
+SPICE map: `L<name> p n {L} IC={IL_init}`.
+
+<!-- BEGIN VERBATIM TABLE: inductor -->
+... ...
+<!-- END VERBATIM TABLE: inductor -->
+
+### Notes
+- Initial current `IL_init` requires UIC in the `.tran` directive on SPICE side.
+- Pin order matters for sign of `i_L` probe.
+```
+
+Apply this to all four components in the file: Resistor, Inductor, Capacitor, Transformer.
+
+For "Wrapped in pyplecs", check the live introspection:
+```bash
+python -c "import pyplecs.plecs_components as c, inspect; print([n for n,_ in inspect.getmembers(c, inspect.isclass)])"
+```
+
+Use the output to label each component as wrapped or not.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: all pass. Specifically `test_caveman_compliance` must pass — banned words like `just`, `really`, `basically` would fail it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/references/components/electrical-passive.md \
+        .claude/skills/plecs-expert/LICENSE-NOTES.md
+git commit -m "feat(skill): caveman prose for electrical-passive components"
+```
+
+---
+
+### Tasks 7–17: Author prose for remaining reference files
+
+Same template as Task 6, applied to:
+
+| Task | File | Source URLs (in manifest.json) |
+|------|------|---------------------------------|
+| 7 | `references/components/electrical-sources.md` | VoltageSourceAC, VoltageSourceDC, VoltageSourceControlled, CurrentSourceControlled |
+| 8 | `references/components/electrical-switches.md` | Mosfet, Igbt, Diode, SwitchIdeal |
+| 9 | `references/components/electrical-meters.md` | Voltmeter, Ammeter, Scope |
+| 10 | `references/components/magnetic.md` | Permeance, MmfSource, FluxMeter |
+| 11 | `references/components/thermal.md` | HeatSink, ThermalCapacitor, AmbientTemperature |
+| 12 | `references/components/control.md` | PIController, TransferFunction, StateMachine |
+| 13 | `references/components/system.md` | Subsystem, ConfigurableSubsystem, Mask |
+| 14 | `references/rpc-api.md` | XmlRpcInterface |
+| 15 | `references/plecs-xml-grammar.md` | PlecsFileFormat |
+| 16 | `references/solver.md` | SolverSettings |
+| 17 | `references/codegen.md` + `references/cscript.md` (combined) | CodeGeneration/Overview, CScript |
+
+**For each task:**
+
+- [ ] Step 1: `cat` the file populated by `sync_tables.py`.
+- [ ] Step 2: Author caveman prose ABOVE each `<!-- BEGIN VERBATIM TABLE -->` block, following the Task 6 template. For non-component pages (RPC, XML grammar, solver, codegen, cscript), adapt the template — drop "Pins" and "SPICE map" lines; keep purpose, "wrapped in pyplecs", and Notes.
+- [ ] Step 3: `pytest tests/test_plecs_expert.py -v` — all pass.
+- [ ] Step 4: Commit with message `feat(skill): caveman prose for <file basename>`.
+
+**Special note for Task 14 (`rpc-api.md`):** the "wrapped in pyplecs" indicator is per RPC function, not per file. For each function in the verbatim table, mark it as wrapped (with the `PlecsServer` method name) or not. Use:
+```bash
+python -c "import inspect; from pyplecs.pyplecs import PlecsServer; print(sorted(n for n,_ in inspect.getmembers(PlecsServer, inspect.isfunction) if not n.startswith('_')))"
+```
+
+**Special note for Task 15 (`plecs-xml-grammar.md`):** the actual `.plecs` file format is sparsely documented online. Supplement the verbatim table with a hand-extracted minimum-viable example from one of the `data/*.plecs` files in this repo (e.g. `data/simple_buck_prb.plecs.bak`). Mark such examples as `<!-- caveman:source: data/simple_buck_prb.plecs.bak (excerpt) -->`.
+
+---
+
+## Phase 4 — URL fallback index
+
+### Task 18: `url-index.md` — long-tail topic table
+
+**Files:**
+- Create: `pyplecs/.claude/skills/plecs-expert/references/url-index.md`
+- Modify: `pyplecs/.claude/skills/plecs-expert/LICENSE-NOTES.md`
+
+- [ ] **Step 1: Write `url-index.md` with topic → URL fallback table**
+
+```markdown
+# URL Fallback Index
+
+Topics not covered offline. Skill should `WebFetch` the URL, summarize in caveman style, cite the URL.
+
+| Topic | URL |
+|-------|-----|
+| RT Box (covered by future plecs-rtbox skill) | https://docs.plexim.com/rtbox/latest/ |
+| Field-oriented control library | https://docs.plexim.com/plecs/latest/UserManual/Control/FOCLibrary.html |
+| MagneticSaturable inductor | https://docs.plexim.com/plecs/latest/UserManual/Magnetic/SaturableInductor.html |
+| Configurable subsystem variants | https://docs.plexim.com/plecs/latest/UserManual/System/ConfigurableSubsystem.html |
+| PLECS Coder target list | https://docs.plexim.com/plecs/latest/UserManual/CodeGeneration/TargetSupport.html |
+| Solver tolerance tuning guide | https://docs.plexim.com/plecs/latest/UserManual/Simulation/Tolerances.html |
+| MATLAB Coder integration | https://docs.plexim.com/plecs/latest/UserManual/CodeGeneration/Matlab.html |
+| Modulator block library | https://docs.plexim.com/plecs/latest/UserManual/Control/Modulators.html |
+| Three-phase machines | https://docs.plexim.com/plecs/latest/UserManual/Electrical/Machines.html |
+| Power semiconductor thermal modeling | https://docs.plexim.com/plecs/latest/UserManual/Thermal/SemiconductorLossTables.html |
+```
+
+> Add more rows as gaps surface during real use.
+
+- [ ] **Step 2: Add row to `LICENSE-NOTES.md`**
+
+```markdown
+| `references/url-index.md` | n/a (URL list only) | n/a | URL pointers (no Plexim prose mirrored) |
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: pass; `test_url_index_resolvable` now scans real URLs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/plecs-expert/references/url-index.md \
+        .claude/skills/plecs-expert/LICENSE-NOTES.md
+git commit -m "feat(skill): url-index.md fallback table"
+```
+
+---
+
+## Phase 5 — Slash command
+
+### Task 19: `/plecs` slash command stub + test
+
+**Files:**
+- Create: `pyplecs/.claude/commands/plecs.md`
+- Modify: `pyplecs/tests/test_plecs_expert.py` (add `test_slash_command_routes`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pyplecs/tests/test_plecs_expert.py`:
+```python
+def test_slash_command_routes():
+    """The /plecs slash command exists and routes to the plecs-expert skill."""
+    cmd = SKILL_ROOT.parent.parent / "commands" / "plecs.md"
+    assert cmd.exists(), f"missing: {cmd}"
+    text = cmd.read_text(encoding="utf-8")
+    assert "plecs-expert" in text, "command does not reference the plecs-expert skill"
+```
+
+- [ ] **Step 2: Run, confirm it fails**
+
+```bash
+pytest tests/test_plecs_expert.py::test_slash_command_routes -v
+```
+
+Expected: FAIL with `missing: ...commands/plecs.md`.
+
+- [ ] **Step 3: Write the slash command**
+
+`pyplecs/.claude/commands/plecs.md`:
+```markdown
+---
+description: Look up PLECS docs (components, RPC, XML format, solver, codegen, C-Script). Routes to the plecs-expert skill.
+allowed-tools: Skill
+---
+
+Use the `plecs-expert` skill to answer the user's question, citing a `.claude/skills/plecs-expert/references/*` file or a `docs.plexim.com` URL. Apply caveman style per `style/caveman.md`.
+
+User question: $ARGUMENTS
+```
+
+- [ ] **Step 4: Run, confirm it passes**
+
+```bash
+pytest tests/test_plecs_expert.py::test_slash_command_routes -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/commands/plecs.md tests/test_plecs_expert.py
+git commit -m "feat(skill): /plecs slash command + routing test"
+```
+
+---
+
+## Phase 6 — MCP server
+
+### Task 20: MCP tool implementations (read-only side)
+
+**Files:**
+- Create: `pyplecs/pyplecs/mcp/plecs_tools.py`
+
+- [ ] **Step 1: Add `mcp` to optional dependencies**
+
+In `pyplecs/pyproject.toml`, add an `mcp` extra:
+```toml
+[project.optional-dependencies]
+mcp = ["mcp>=1.0"]
+dev = [
+    # ... existing entries ...
+    "mcp>=1.0",
+]
+```
+
+- [ ] **Step 2: Install + write the tool module**
+
+```bash
+pip install -e ".[dev]"
+```
+
+`pyplecs/pyplecs/mcp/plecs_tools.py`:
+```python
+"""Read-only MCP tools backed by the plecs-expert skill content + pyplecs introspection."""
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+# Resolve skill root: pyplecs repo .claude/skills/plecs-expert/
+PYPLECS_PKG = Path(__file__).resolve().parent.parent  # pyplecs/pyplecs
+REPO_ROOT = PYPLECS_PKG.parent  # pyplecs/
+SKILL_ROOT = REPO_ROOT / ".claude" / "skills" / "plecs-expert"
+REFERENCES = SKILL_ROOT / "references"
+
+
+def _read_ref(rel: str) -> str:
+    path = REFERENCES / rel
+    if not path.exists():
+        return f"(no offline reference for `{rel}`)"
+    return path.read_text(encoding="utf-8")
+
+
+def plecs_lookup(topic: str) -> str:
+    """Read references/<topic>.md (or .md added if missing)."""
+    rel = topic if topic.endswith(".md") else f"{topic}.md"
+    return _read_ref(rel)
+
+
+def plecs_search(query: str) -> str:
+    """Grep across references/ for `query`. Returns file:line matches."""
+    if not REFERENCES.exists():
+        return "(references/ not yet populated)"
+    needle = query.lower()
+    matches: list[str] = []
+    for md in sorted(REFERENCES.rglob("*.md")):
+        for i, line in enumerate(md.read_text(encoding="utf-8").splitlines(), start=1):
+            if needle in line.lower():
+                matches.append(f"{md.relative_to(SKILL_ROOT)}:{i}: {line.strip()}")
+    return "\n".join(matches) if matches else f"no matches for '{query}'"
+
+
+def plecs_xml(element: str) -> str:
+    """Look up a `.plecs` XML element in plecs-xml-grammar.md."""
+    text = _read_ref("plecs-xml-grammar.md")
+    pattern = re.compile(rf"`<{re.escape(element)}\b.*", re.IGNORECASE)
+    matches = pattern.findall(text)
+    if matches:
+        return "\n".join(matches[:10])
+    return f"element `<{element}>` not documented; try plecs_url('xml-grammar')"
+
+
+def plecs_url(topic: str) -> str:
+    """Return the docs.plexim.com URL for `topic` from url-index.md."""
+    text = _read_ref("url-index.md")
+    needle = topic.lower()
+    for line in text.splitlines():
+        if needle in line.lower():
+            urls = re.findall(r"https?://[^\s)>\]]+", line)
+            if urls:
+                return urls[0]
+    return f"no URL fallback for '{topic}'"
+
+
+def pyplecs_wrappers() -> list[str]:
+    """List `*PlecsMdl` classes in pyplecs.plecs_components."""
+    import pyplecs.plecs_components as comps
+    return sorted(
+        n for n, obj in inspect.getmembers(comps, inspect.isclass)
+        if obj.__module__ == comps.__name__
+    )
+
+
+def pyplecs_rpc_surface() -> list[str]:
+    """List PlecsServer public methods."""
+    from pyplecs.pyplecs import PlecsServer
+    return sorted(
+        n for n, _ in inspect.getmembers(PlecsServer, predicate=inspect.isfunction)
+        if not n.startswith("_")
+    )
+
+
+def plecs_component(name: str) -> dict[str, Any]:
+    """Composed: pyplecs wrapper if present, else search references/components/."""
+    wrappers = pyplecs_wrappers()
+    matched_wrapper = next((w for w in wrappers if name.lower() in w.lower()), None)
+    body = {
+        "name": name,
+        "pyplecs_wrapper": matched_wrapper,
+        "docs_excerpt": plecs_search(name),
+    }
+    return body
+
+
+def plecs_rpc(function: str) -> dict[str, Any]:
+    """Composed: PlecsServer method introspection if present, else docs lookup."""
+    from pyplecs.pyplecs import PlecsServer
+    method = getattr(PlecsServer, function, None)
+    body: dict[str, Any] = {
+        "function": function,
+        "wrapped_in_pyplecs": method is not None,
+    }
+    if method is not None:
+        try:
+            sig = str(inspect.signature(method))
+        except (TypeError, ValueError):
+            sig = "(signature not introspectable)"
+        body["signature"] = f"PlecsServer.{function}{sig}"
+        body["docstring"] = inspect.getdoc(method) or ""
+    body["docs_excerpt"] = plecs_search(function)
+    return body
+
+
+# Registry consumed by server.py and the test
+TOOL_REGISTRY: dict[str, Any] = {
+    "plecs_lookup": plecs_lookup,
+    "plecs_search": plecs_search,
+    "plecs_xml": plecs_xml,
+    "plecs_url": plecs_url,
+    "plecs_component": plecs_component,
+    "plecs_rpc": plecs_rpc,
+    "pyplecs_wrappers": pyplecs_wrappers,
+    "pyplecs_rpc_surface": pyplecs_rpc_surface,
+}
+
+
+__all__ = ["TOOL_REGISTRY", *TOOL_REGISTRY.keys()]
+```
+
+- [ ] **Step 3: Smoke-test the tool functions directly**
+
+```bash
+python -c "
+from pyplecs.mcp.plecs_tools import TOOL_REGISTRY, pyplecs_wrappers, plecs_search
+print('tools:', sorted(TOOL_REGISTRY))
+print('wrappers:', pyplecs_wrappers())
+print('search MOSFET:', plecs_search('MOSFET')[:200])
+"
+```
+
+Expected: prints the 8 tool names, the wrapper class list (`MosfetWithDiodePlecsMdl`, `ResistorPlecsMdl`, ...), and a few `references/.../*.md:NN:` matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyplecs/mcp/plecs_tools.py pyproject.toml
+git commit -m "feat(mcp): plecs_tools registry — 8 read-only MCP tools"
+```
+
+---
+
+### Task 21: MCP server boilerplate + entry point
+
+**Files:**
+- Create: `pyplecs/pyplecs/mcp/server.py`
+- Modify: `pyplecs/pyplecs/mcp/__init__.py`
+- Modify: `pyplecs/pyproject.toml`
+
+- [ ] **Step 1: Write the server**
+
+`pyplecs/pyplecs/mcp/server.py`:
+```python
+"""Stdio MCP server exposing the plecs-expert tools."""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from .plecs_tools import TOOL_REGISTRY
+
+
+def _to_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, indent=2, default=str)
+
+
+def build_server() -> Server:
+    server: Server = Server("pyplecs-mcp")
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name=name,
+                description=(fn.__doc__ or name).strip().splitlines()[0],
+                inputSchema={
+                    "type": "object",
+                    "properties": {"argument": {"type": "string"}},
+                    "required": [],
+                },
+            )
+            for name, fn in TOOL_REGISTRY.items()
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        fn = TOOL_REGISTRY.get(name)
+        if fn is None:
+            return [TextContent(type="text", text=f"unknown tool: {name}")]
+        arg = arguments.get("argument", "")
+        try:
+            result = fn(arg) if arg else fn()
+        except TypeError:
+            result = fn()
+        return [TextContent(type="text", text=_to_text(result))]
+
+    return server
+
+
+async def _serve() -> None:
+    server = build_server()
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+def main() -> int:
+    try:
+        asyncio.run(_serve())
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:
+        print(f"pyplecs-mcp error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Wire `__init__.py`**
+
+Replace `pyplecs/pyplecs/mcp/__init__.py`:
+```python
+"""MCP server for PyPLECS.
+
+Exposes the plecs-expert skill content and pyplecs introspection over stdio.
+"""
+from __future__ import annotations
+
+
+def create_mcp_server():
+    """Create and return the MCP server instance (for embedding/testing)."""
+    from .server import build_server
+    return build_server()
+
+
+def main() -> int:
+    """Entry point for the `pyplecs-mcp` console script."""
+    from .server import main as _main
+    return _main()
+
+
+__all__ = ["create_mcp_server", "main"]
+```
+
+- [ ] **Step 3: Add the entry point to `pyproject.toml`**
+
+```toml
+[project.scripts]
+pyplecs-api = "pyplecs.api:main"
+pyplecs-setup = "pyplecs.cli.installer:main"
+pyplecs-gui = "pyplecs.webgui:run_app"
+pyplecs-mcp = "pyplecs.mcp:main"
+```
+
+- [ ] **Step 4: Reinstall the package so the entry point registers**
+
+```bash
+pip install -e ".[dev]"
+```
+
+- [ ] **Step 5: Smoke-test server construction (no stdio loop)**
+
+```bash
+python -c "from pyplecs.mcp import create_mcp_server; s = create_mcp_server(); print(type(s).__name__)"
+```
+
+Expected: prints `Server`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyplecs/mcp/__init__.py pyplecs/mcp/server.py pyproject.toml
+git commit -m "feat(mcp): pyplecs-mcp stdio server + entry point"
+```
+
+---
+
+### Task 22: MCP-side tests + introspection guarantees
+
+**Files:**
+- Modify: `pyplecs/tests/test_plecs_expert.py`
+
+- [ ] **Step 1: Append the two MCP-related tests**
+
+Append to `pyplecs/tests/test_plecs_expert.py`:
+```python
+EXPECTED_MCP_TOOLS = {
+    "plecs_lookup",
+    "plecs_search",
+    "plecs_xml",
+    "plecs_url",
+    "plecs_component",
+    "plecs_rpc",
+    "pyplecs_wrappers",
+    "pyplecs_rpc_surface",
+}
+
+
+def test_pyplecs_wrappers_introspectable():
+    """pyplecs.plecs_components imports clean and exposes *PlecsMdl classes."""
+    import pyplecs.plecs_components as comps  # noqa: F401
+    from pyplecs.mcp.plecs_tools import pyplecs_wrappers
+
+    wrappers = pyplecs_wrappers()
+    assert wrappers, "no wrapper classes found in pyplecs.plecs_components"
+    assert any(w.endswith("PlecsMdl") for w in wrappers), (
+        f"expected *PlecsMdl naming convention; got: {wrappers}"
+    )
+
+
+def test_mcp_tools_register():
+    """Importing pyplecs.mcp.plecs_tools exposes the expected 8 tools."""
+    from pyplecs.mcp.plecs_tools import TOOL_REGISTRY
+
+    assert set(TOOL_REGISTRY) == EXPECTED_MCP_TOOLS, (
+        f"tool registry mismatch: extra={set(TOOL_REGISTRY) - EXPECTED_MCP_TOOLS} "
+        f"missing={EXPECTED_MCP_TOOLS - set(TOOL_REGISTRY)}"
+    )
+    # Each entry is callable
+    for name, fn in TOOL_REGISTRY.items():
+        assert callable(fn), f"{name} not callable"
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+pytest tests/test_plecs_expert.py::test_pyplecs_wrappers_introspectable tests/test_plecs_expert.py::test_mcp_tools_register -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 3: Run the full test suite for this file**
+
+```bash
+pytest tests/test_plecs_expert.py -v
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 4: Run ruff**
+
+```bash
+ruff check .
+```
+
+Expected: clean. Fix any issues (likely import ordering in the new files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_plecs_expert.py
+git commit -m "test(mcp): registry + introspection tests"
+```
+
+---
+
+## Phase 7 — Final integration
+
+### Task 23: Manual smoke test + PR
+
+**Files:**
+- No code changes (verification + PR open).
+
+- [ ] **Step 1: Run the platform-independent test subset (matches pre-push hook)**
+
+```bash
+pytest -q tests/test_installer.py tests/test_entrypoint.py tests/test_install_full.py tests/test_abc_contract.py tests/test_plecs_expert.py
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Run ruff once more**
+
+```bash
+ruff check .
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Manual stdio smoke test of `pyplecs-mcp`**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | pyplecs-mcp 2>/dev/null | head -200
+```
+
+Expected: a JSON response listing the 8 tools by name. (Real MCP clients use the `mcp` SDK handshake; this raw probe is a sanity check that the server starts and responds.) If you have Claude Desktop installed, register `pyplecs-mcp` in its `claude_desktop_config.json` and call `plecs_component("Inductor")` for an end-to-end check.
+
+- [ ] **Step 4: Update `CLAUDE.md` with the new skill + MCP server**
+
+Add a row to the Decision Log:
+```markdown
+| 2026-04-27 | Add `plecs-expert` skill + `pyplecs-mcp` MCP server | Ground PLECS authoring help, netlist converter, and PlecsServer wrapper in docs.plexim.com via offline caveman-style reference. Closes #23. |
+```
+
+Add to "Key Documents":
+```markdown
+- [PLECS Expert Skill](.claude/skills/plecs-expert/SKILL.md) — PLECS docs reference (offline + URL fallback)
+```
+
+Add to "Architecture quick reference":
+```markdown
+- **PLECS docs reference at `.claude/skills/plecs-expert/`** — single source of truth for the skill, `/plecs` command, and `pyplecs-mcp` MCP server. Refresh procedure in `.claude/skills/plecs-expert/tools/REFRESH.md`.
+```
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin feature/plecs-expert-skill
+```
+
+Expected: pre-push hook runs ruff + the platform-independent test set; both pass.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "feat: plecs-expert skill + pyplecs-mcp MCP server (closes #23)" --body "$(cat <<'EOF'
+## Summary
+- Add `plecs-expert` Claude Code skill at `.claude/skills/plecs-expert/`, grounded in `docs.plexim.com/plecs/latest/`
+- Triple delivery: Claude Code skill, `/plecs` slash command, `pyplecs-mcp` stdio MCP server
+- Two-layer composition: offline reference (verbatim factual tables + caveman-style rewritten prose) + live `pyplecs` introspection
+- Refresh tooling (`sync_tables.py`, `check_drift.py`, `REFRESH.md`) and 8 platform-independent tests
+
+Closes #23.
+
+## Test plan
+- [ ] `ruff check .` clean
+- [ ] `pytest tests/test_plecs_expert.py` — 8/8 pass
+- [ ] Pre-push hook (ruff + 5 platform-independent test files) green
+- [ ] `pyplecs-mcp` starts; `tools/list` returns 8 tools
+- [ ] Manual: Claude Desktop registers `pyplecs-mcp` and answers `plecs_component("Inductor")` with composed pyplecs+docs answer
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 7: Confirm completion criteria**
+
+Read [`docs/superpowers/specs/2026-04-27-plecs-expert-skill-design.md`](../specs/2026-04-27-plecs-expert-skill-design.md) — "Completion criteria" section. Tick each off:
+
+1. ☐ `pyplecs/.claude/skills/plecs-expert/` populated for Full scope minus RT Box
+2. ☐ `.claude/commands/plecs.md` slash-command stub exists
+3. ☐ `pyplecs/mcp/` implements `create_mcp_server()` + `main()` over stdio with the 8 read-only tools
+4. ☐ `pyproject.toml` registers `pyplecs-mcp = "pyplecs.mcp:main"`
+5. ☐ `tests/test_plecs_expert.py` passes in the platform-independent subset
+6. ☐ `ruff check .` clean
+7. ☐ Manual smoke test passed
+8. ☐ PR opened referencing #23
+
+---
+
+## Out of scope (do NOT do as part of this plan)
+
+- RT Box content (separate `plecs-rtbox` skill, future).
+- Simulation execution as MCP tool (separate `plecs-runner` skill, future).
+- HTTP MCP transport.
+- Auto-publishing `references/` to mkdocs / GitHub Pages — content stays under `.claude/`.
+- Rewriting `pyplecs.plecs_components.py` to expand wrapper coverage.
+- Portability of the skill folder as standalone drop-in.

--- a/docs/superpowers/specs/2026-04-27-plecs-expert-skill-design.md
+++ b/docs/superpowers/specs/2026-04-27-plecs-expert-skill-design.md
@@ -1,0 +1,207 @@
+# PLECS-Expert Skill — Design Spec
+
+**Date**: 2026-04-27
+**Status**: Draft (awaiting user review)
+**Author**: Riccardo Tinivella + Claude
+**Branch**: `feature/plecs-expert-skill`
+**Closes**: [#23 — add skills for claude](https://github.com/tinix84/pyplecs/issues/23)
+
+## Summary
+
+Add a `plecs-expert` Claude Code skill grounded in [docs.plexim.com/plecs/latest](https://docs.plexim.com/plecs/latest/), exposed three ways: as a Claude Code skill, as a `/plecs` slash command, and as a stdio MCP server (`pyplecs-mcp`). The skill answers PLECS authoring questions, supports the `.plecs → SPICE` netlist converter, and grounds the `PlecsServer` XML-RPC wrapper in the official API.
+
+Content uses a hybrid sourcing strategy — verbatim factual tables (parameters, RPC signatures, XML grammar — facts, not copyrightable) plus prose rewritten in the [caveman](https://github.com/juliusbrussee/caveman) terse-fragment style — and composes answers from two layers: the offline PLECS docs reference and live introspection of `pyplecs` modules. The skill is tied to the pyplecs repo (not portable standalone) so it can call `pyplecs` as a token-saving runtime tool.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | New dedicated skill (not extending `pe-expert`) | `pe-expert` stays tool-agnostic (Erickson/Maksimovic theory). Tool-specific PLECS knowledge belongs in its own skill. |
+| 2 | Use-case priority: authoring → converter → wrapper | User-set ranking. Authoring is daily; converter and wrapper are bounded sub-projects benefiting from the same content. |
+| 3 | Hybrid sourcing: offline reference + URL fallback | Lookup speed for common topics (offline), coverage breadth for long-tail (WebFetch). |
+| 4 | Full content scope minus RT Box | RT Box becomes a separate future skill. All other PLECS chapters (components, RPC, XML, solver, masks, codegen, magnetics/thermal, C-Script, control library) are in scope. |
+| 5 | Stance C: factual tables verbatim, prose rewritten | Facts aren't copyrightable; rewritten prose avoids the gray-zone of mirroring proprietary docs. Repo is public. |
+| 6 | Caveman style for all rewritten prose | Token efficiency, uniform style, defensive against accidental verbatim copying. |
+| 7 | Skill lives in `pyplecs/.claude/skills/plecs-expert/` (not in WSL agents_pool) | Tied to pyplecs so the skill can use pyplecs as a runtime introspection tool. |
+| 8 | Production pipeline: scripted extractor for tables, hand-authored caveman prose | Caveman quality stays high (humans do it); tables stay accurate cheaply. |
+| 9 | Triple delivery surface: Skill + slash command + MCP server | Same `references/` content, three access paths. |
+| 10 | Stdio-only MCP transport | Matches Claude Desktop and existing `pyplecs-mcp` advertisement. HTTP excluded. |
+| 11 | MCP surface read-only | No simulation execution. Future `plecs-runner` skill if needed. |
+| 12 | Live introspection over snapshot for pyplecs layer | MCP server already imports pyplecs; `inspect.getmembers` is free and drift-free by construction. |
+
+## Architecture
+
+Two knowledge layers composed at query time:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│              pyplecs/.claude/skills/plecs-expert/               │
+│                                                                 │
+│   Layer A: PLECS docs (offline + URL fallback)                  │
+│     references/components/*.md, rpc-api.md, plecs-xml-grammar.md│
+│     solver.md, codegen.md, cscript.md, url-index.md             │
+│                                                                 │
+│   Layer B: PyPLECS code (live introspection)                    │
+│     pyplecs.plecs_components → wrapper classes                  │
+│     pyplecs.pyplecs.PlecsServer → XML-RPC surface               │
+│                                                                 │
+│   Composer: SKILL.md routing + MCP tool implementations         │
+│     1. Wrapper exists in Layer B? → cite wrapper                │
+│     2. Else Layer A? → cite reference file                      │
+│     3. Else url-index.md? → WebFetch + cite URL                 │
+└─────────────────────────────────────────────────────────────────┘
+                ↓             ↓                ↓
+        Claude Code   /plecs slash    pyplecs-mcp (stdio)
+        skill auto-   command         MCP server consumed
+        triggered                     by external clients
+```
+
+## File layout
+
+```
+pyplecs/
+├── .claude/
+│   ├── commands/
+│   │   └── plecs.md                    # NEW: /plecs slash command
+│   └── skills/
+│       └── plecs-expert/               # NEW: single source of truth (read by skill, /plecs, MCP)
+│           ├── SKILL.md                # Frontmatter + activation + index (≤ 4 KB)
+│           ├── LICENSE-NOTES.md        # Verbatim/rewritten boundary, source URLs
+│           ├── style/
+│           │   └── caveman.md          # Prose style rules (banned words, patterns)
+│           ├── references/
+│           │   ├── components/
+│           │   │   ├── electrical-passive.md
+│           │   │   ├── electrical-sources.md
+│           │   │   ├── electrical-switches.md
+│           │   │   ├── electrical-meters.md
+│           │   │   ├── magnetic.md
+│           │   │   ├── thermal.md
+│           │   │   ├── control.md
+│           │   │   └── system.md
+│           │   ├── rpc-api.md
+│           │   ├── plecs-xml-grammar.md
+│           │   ├── solver.md
+│           │   ├── codegen.md
+│           │   ├── cscript.md
+│           │   └── url-index.md
+│           ├── manifest.json           # Source URL → content hash (drift detection)
+│           └── tools/
+│               ├── sync_tables.py      # Scrape & extract factual tables verbatim
+│               ├── check_drift.py      # Diff manifest hashes; diff pyplecs introspection
+│               └── REFRESH.md          # Human refresh procedure
+└── pyplecs/
+    └── mcp/
+        ├── __init__.py                 # CHANGE: implement create_mcp_server / main
+        ├── server.py                   # NEW: MCP stdio server boilerplate
+        └── plecs_tools.py              # NEW: tool implementations (read references + introspect)
+```
+
+## SKILL.md shape
+
+Frontmatter:
+
+```yaml
+---
+name: plecs-expert
+description: PLECS authoring help, .plecs schematic format, XML-RPC API, and SPICE-mapping reference. Use when answering "how do I X in PLECS", working on the netlist converter, or extending the PlecsServer XML-RPC wrapper.
+allowed-tools: Read, Grep, Glob, WebFetch, Bash
+---
+```
+
+Body sections (caveman style, ≤ 4 KB total):
+
+1. **What this skill knows** — topic → file table.
+2. **How to use** — terse routing rules: components → `references/components/<family>.md`; RPC → `references/rpc-api.md`; XML → `references/plecs-xml-grammar.md`; long-tail → `references/url-index.md` + WebFetch.
+3. **Composition rule** — check `pyplecs.plecs_components` and `PlecsServer` first; cite wrapper if present; else cite reference; else WebFetch URL.
+4. **Citation rule** — every answer cites a `references/*` path or a `docs.plexim.com` URL. No ungrounded claims.
+5. **Caveman style enforcement** — generated prose follows `style/caveman.md`.
+6. **Boundary** — does not cover RT Box, license/purchasing decisions, or third-party libraries. RT Box → future skill.
+
+## MCP surface
+
+All read-only, stdio transport, registered via `pyplecs-mcp = "pyplecs.mcp:main"`.
+
+| Tool | Layer | Purpose |
+|------|-------|---------|
+| `plecs_lookup(topic)` | docs | Read `references/<topic>.md` |
+| `plecs_search(query)` | docs | Grep across `references/` |
+| `plecs_component(name)` | composed | pyplecs wrapper if present, else docs reference |
+| `plecs_rpc(function)` | composed | introspect `PlecsServer.<function>` if present, else docs |
+| `plecs_xml(element)` | docs | `.plecs` XML element grammar lookup |
+| `plecs_url(topic)` | docs | docs.plexim.com URL fallback |
+| `pyplecs_wrappers()` | pyplecs | List `*PlecsMdl` classes in `pyplecs.plecs_components` |
+| `pyplecs_rpc_surface()` | pyplecs | List `PlecsServer` public methods |
+
+Excluded: anything that runs PLECS, opens models, or writes files.
+
+## Content posture & licensing
+
+`docs.plexim.com` content is Plexim's proprietary documentation. The repo is public. Posture:
+
+- **Verbatim** — factual tables only: parameter names, defaults, units, RPC function signatures, `.plecs` XML element grammar. Facts are not copyrightable in any jurisdiction relevant here.
+- **Rewritten** — all explanatory prose, in caveman style per `style/caveman.md`. Original authorship; no copy/paste from Plexim docs.
+- **`LICENSE-NOTES.md`** — for every `references/*.md` file, classifies sections as `verbatim:tables` or `rewritten:prose` and lists the source URL. Auditable boundary.
+
+If Plexim ever objects, the verbatim factual tables are the only thing that could carry risk; the rewritten prose is original. The `LICENSE-NOTES.md` makes a takedown surgical rather than a full skill removal.
+
+## Refresh procedure
+
+Pinned to a PLECS minor version per refresh cycle. Recorded in `manifest.json`.
+
+1. `python .claude/skills/plecs-expert/tools/check_drift.py`
+   - Fetches each URL in `manifest.json`, hashes content, compares to stored hash.
+   - Introspects `pyplecs.plecs_components` and `PlecsServer`, diffs against last snapshot.
+   - Output: a Markdown report listing prose pages to re-author + wrapped/not-wrapped status flips.
+2. `python .claude/skills/plecs-expert/tools/sync_tables.py`
+   - Re-extracts factual tables verbatim from URLs in `manifest.json`.
+   - Updates table sections of each `references/*.md` in place; leaves prose untouched.
+   - Refreshes `manifest.json` hashes.
+3. Human pass: re-author flagged prose in caveman style per `style/caveman.md`.
+4. `pytest tests/test_plecs_expert.py`.
+5. Commit.
+
+## Testing
+
+New file `tests/test_plecs_expert.py`. All tests platform-independent (no PLECS instance, no network) so they run in the pre-push hook subset.
+
+| Test | Checks | Why |
+|------|--------|-----|
+| `test_skill_md_under_4kb` | `SKILL.md` size budget | Body must stay lookup-fast |
+| `test_references_no_dead_links` | every `[label](path)` resolves to an existing file | Skill answers depend on file existence |
+| `test_url_index_resolvable` | URLs in `url-index.md` are syntactically valid (no fetch) | Cheap sanity, not a network test |
+| `test_caveman_compliance` | rewritten prose blocks pass caveman lint (banned filler list) | Style enforcement |
+| `test_license_notes_complete` | every `references/*.md` is listed in `LICENSE-NOTES.md` with classification | Auditability |
+| `test_pyplecs_wrappers_introspectable` | `pyplecs.plecs_components` imports clean, has expected `*PlecsMdl` classes | MCP composition layer works |
+| `test_mcp_tools_register` | importing `pyplecs.mcp` exposes the expected tool names via the registry | MCP server is wired (no subprocess required in CI) |
+| `test_slash_command_routes` | `.claude/commands/plecs.md` exists and references the `plecs-expert` skill | Slash command path works |
+
+## Completion criteria
+
+1. `pyplecs/.claude/skills/plecs-expert/` exists with `SKILL.md`, `LICENSE-NOTES.md`, `style/caveman.md`, populated `references/` for the Full scope minus RT Box, `manifest.json`, `tools/`.
+2. `pyplecs/.claude/commands/plecs.md` slash-command stub exists.
+3. `pyplecs/pyplecs/mcp/` implements `create_mcp_server()` + `main()` over stdio with the 8 read-only tools.
+4. `pyproject.toml` registers `pyplecs-mcp = "pyplecs.mcp:main"`.
+5. `tests/test_plecs_expert.py` passes in the platform-independent subset.
+6. `ruff check .` clean.
+7. Manual smoke test: `pyplecs-mcp` invoked from Claude Desktop responds to `plecs_component("Inductor")` with composed pyplecs+docs answer.
+8. Issue #23 closed by the merging PR.
+
+## Out of scope
+
+- RT Box content (separate future skill).
+- Simulation execution via MCP (separate future `plecs-runner` skill).
+- HTTP MCP transport.
+- Auto-publish of `references/` to mkdocs / GitHub Pages — content lives under `.claude/`, not `docs/`, on purpose.
+- Rewriting `pyplecs.plecs_components.py` to expand wrapper coverage (separate work; this skill consumes what's there).
+- Portability of the skill folder as standalone drop-in (it depends on pyplecs as a runtime tool).
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Plexim doc-site HTML structure changes break `sync_tables.py` | Parser is ≤ 200 LOC; refresh procedure expects to occasionally hand-fix it. Not run in CI. |
+| Caveman-style enforcement test produces false positives on legitimate technical prose | Banned-words list is small and reviewed; test prints offending file:line for easy override via inline `<!-- caveman:allow -->` markers. |
+| MCP server import-time errors brick `pyplecs-mcp` startup | `test_mcp_tools_register` imports the module + checks the tool registry; subprocess smoke is part of completion-criteria #7 (manual). |
+| Live introspection of `PlecsServer` triggers network calls | `pyplecs_rpc_surface()` uses `inspect.getmembers` only — no instantiation, no XML-RPC connection. |
+| Public repo accidentally publishes verbatim Plexim prose | `test_caveman_compliance` + `LICENSE-NOTES.md` discipline. PR review checks `LICENSE-NOTES.md` was updated alongside any `references/*.md` change. |

--- a/pyplecs/contracts.py
+++ b/pyplecs/contracts.py
@@ -46,8 +46,6 @@ _source = _resolve_source()
 if _source == "pypi":
     try:
         # StructuredLoggerBase is missing from upstream __all__; import directly:
-        from pycircuitsim_core.logging import StructuredLoggerBase  # type: ignore[import-not-found]
-
         from pycircuitsim_core import (  # type: ignore[import-not-found]
             ConfigManagerBase,
             SimulationCacheBase,
@@ -60,6 +58,7 @@ if _source == "pypi":
             SyncSimulationResponse,
             TaskPriority,
         )
+        from pycircuitsim_core.logging import StructuredLoggerBase  # type: ignore[import-not-found]
     except ImportError:
         # External pycircuitsim_core is importable as a package but one or
         # more expected names is missing (upstream rename, partial install,

--- a/pyplecs/mcp/__init__.py
+++ b/pyplecs/mcp/__init__.py
@@ -1,19 +1,26 @@
 """MCP server for PyPLECS.
 
 Exposes the plecs-expert skill content and pyplecs introspection over stdio.
+
+The `mcp` SDK is an OPTIONAL dependency. Importing this module raises
+ImportError when `mcp` isn't installed, which lets the top-level
+`pyplecs/__init__.py` degrade `create_mcp_server` to None on a clean
+`pip install pyplecs` (without the `[mcp]` extra). Install with
+`pip install pyplecs[mcp]`.
 """
 from __future__ import annotations
+
+from .server import build_server
+from .server import main as _main
 
 
 def create_mcp_server():
     """Create and return the MCP server instance (for embedding/testing)."""
-    from .server import build_server
     return build_server()
 
 
 def main() -> int:
     """Entry point for the `pyplecs-mcp` console script."""
-    from .server import main as _main
     return _main()
 
 

--- a/pyplecs/mcp/__init__.py
+++ b/pyplecs/mcp/__init__.py
@@ -1,14 +1,20 @@
-"""MCP server for PyPLECS (placeholder)."""
+"""MCP server for PyPLECS.
+
+Exposes the plecs-expert skill content and pyplecs introspection over stdio.
+"""
+from __future__ import annotations
 
 
 def create_mcp_server():
-    """Create MCP server instance."""
-    raise NotImplementedError("MCP server not yet implemented")
+    """Create and return the MCP server instance (for embedding/testing)."""
+    from .server import build_server
+    return build_server()
 
 
-def main():
-    """Entry point for pyplecs-mcp command."""
-    print("PyPLECS MCP server not yet implemented")
+def main() -> int:
+    """Entry point for the `pyplecs-mcp` console script."""
+    from .server import main as _main
+    return _main()
 
 
 __all__ = ["create_mcp_server", "main"]

--- a/pyplecs/mcp/plecs_tools.py
+++ b/pyplecs/mcp/plecs_tools.py
@@ -15,13 +15,24 @@ PYPLECS_PKG = Path(__file__).resolve().parent.parent  # <repo>/pyplecs
 REPO_ROOT = PYPLECS_PKG.parent  # <repo>
 SKILL_ROOT = REPO_ROOT / ".claude" / "skills" / "plecs-expert"
 REFERENCES = SKILL_ROOT / "references"
+_REFERENCES_RESOLVED = REFERENCES.resolve()
 
 
 def _read_ref(rel: str) -> str:
-    path = REFERENCES / rel
-    if not path.exists():
+    """Read references/<rel>; reject path-traversal attempts.
+
+    `rel` is treated as a path under REFERENCES. After resolving, the path
+    must be inside REFERENCES — otherwise the call is rejected. This prevents
+    a malicious MCP client from passing e.g. `../../../etc/passwd`.
+    """
+    candidate = (REFERENCES / rel).resolve()
+    try:
+        candidate.relative_to(_REFERENCES_RESOLVED)
+    except ValueError:
+        return f"(invalid reference path: {rel})"
+    if not candidate.exists():
         return f"(no offline reference for `{rel}`)"
-    return path.read_text(encoding="utf-8")
+    return candidate.read_text(encoding="utf-8")
 
 
 def plecs_lookup(topic: str) -> str:

--- a/pyplecs/mcp/plecs_tools.py
+++ b/pyplecs/mcp/plecs_tools.py
@@ -1,0 +1,130 @@
+"""Read-only MCP tools backed by the plecs-expert skill content + pyplecs introspection."""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import Any
+
+# Resolve skill root: <repo>/.claude/skills/plecs-expert/
+# __file__              = <repo>/pyplecs/mcp/plecs_tools.py
+# .parent               = <repo>/pyplecs/mcp
+# .parent.parent        = <repo>/pyplecs   (the package dir)
+# .parent.parent.parent = <repo>           (repo root, where .claude/ lives)
+PYPLECS_PKG = Path(__file__).resolve().parent.parent  # <repo>/pyplecs
+REPO_ROOT = PYPLECS_PKG.parent  # <repo>
+SKILL_ROOT = REPO_ROOT / ".claude" / "skills" / "plecs-expert"
+REFERENCES = SKILL_ROOT / "references"
+
+
+def _read_ref(rel: str) -> str:
+    path = REFERENCES / rel
+    if not path.exists():
+        return f"(no offline reference for `{rel}`)"
+    return path.read_text(encoding="utf-8")
+
+
+def plecs_lookup(topic: str) -> str:
+    """Read references/<topic>.md (or .md added if missing)."""
+    rel = topic if topic.endswith(".md") else f"{topic}.md"
+    return _read_ref(rel)
+
+
+def plecs_search(query: str) -> str:
+    """Grep across references/ for `query`. Returns file:line matches."""
+    if not REFERENCES.exists():
+        return "(references/ not yet populated)"
+    needle = query.lower()
+    matches: list[str] = []
+    for md in sorted(REFERENCES.rglob("*.md")):
+        for i, line in enumerate(md.read_text(encoding="utf-8").splitlines(), start=1):
+            if needle in line.lower():
+                matches.append(f"{md.relative_to(SKILL_ROOT)}:{i}: {line.strip()}")
+    return "\n".join(matches) if matches else f"no matches for '{query}'"
+
+
+def plecs_xml(element: str) -> str:
+    """Look up a `.plecs` XML element in plecs-xml-grammar.md."""
+    text = _read_ref("plecs-xml-grammar.md")
+    pattern = re.compile(rf"`<{re.escape(element)}\b.*", re.IGNORECASE)
+    matches = pattern.findall(text)
+    if matches:
+        return "\n".join(matches[:10])
+    return f"element `<{element}>` not documented; try plecs_url('xml-grammar')"
+
+
+def plecs_url(topic: str) -> str:
+    """Return the docs.plexim.com URL for `topic` from url-index.md."""
+    text = _read_ref("url-index.md")
+    needle = topic.lower()
+    for line in text.splitlines():
+        if needle in line.lower():
+            urls = re.findall(r"https?://[^\s)>\]]+", line)
+            if urls:
+                return urls[0]
+    return f"no URL fallback for '{topic}'"
+
+
+def pyplecs_wrappers() -> list[str]:
+    """List `*PlecsMdl` classes in pyplecs.plecs_components."""
+    import pyplecs.plecs_components as comps
+    return sorted(
+        n for n, obj in inspect.getmembers(comps, inspect.isclass)
+        if obj.__module__ == comps.__name__
+    )
+
+
+def pyplecs_rpc_surface() -> list[str]:
+    """List PlecsServer public methods."""
+    from pyplecs.pyplecs import PlecsServer
+    return sorted(
+        n for n, _ in inspect.getmembers(PlecsServer, predicate=inspect.isfunction)
+        if not n.startswith("_")
+    )
+
+
+def plecs_component(name: str) -> dict[str, Any]:
+    """Composed: pyplecs wrapper if present, else search references/components/."""
+    wrappers = pyplecs_wrappers()
+    matched_wrapper = next((w for w in wrappers if name.lower() in w.lower()), None)
+    body = {
+        "name": name,
+        "pyplecs_wrapper": matched_wrapper,
+        "docs_excerpt": plecs_search(name),
+    }
+    return body
+
+
+def plecs_rpc(function: str) -> dict[str, Any]:
+    """Composed: PlecsServer method introspection if present, else docs lookup."""
+    from pyplecs.pyplecs import PlecsServer
+    method = getattr(PlecsServer, function, None)
+    body: dict[str, Any] = {
+        "function": function,
+        "wrapped_in_pyplecs": method is not None,
+    }
+    if method is not None:
+        try:
+            sig = str(inspect.signature(method))
+        except (TypeError, ValueError):
+            sig = "(signature not introspectable)"
+        body["signature"] = f"PlecsServer.{function}{sig}"
+        body["docstring"] = inspect.getdoc(method) or ""
+    body["docs_excerpt"] = plecs_search(function)
+    return body
+
+
+# Registry consumed by server.py and the test
+TOOL_REGISTRY: dict[str, Any] = {
+    "plecs_lookup": plecs_lookup,
+    "plecs_search": plecs_search,
+    "plecs_xml": plecs_xml,
+    "plecs_url": plecs_url,
+    "plecs_component": plecs_component,
+    "plecs_rpc": plecs_rpc,
+    "pyplecs_wrappers": pyplecs_wrappers,
+    "pyplecs_rpc_surface": pyplecs_rpc_surface,
+}
+
+
+__all__ = ["TOOL_REGISTRY", *TOOL_REGISTRY.keys()]

--- a/pyplecs/mcp/plecs_tools.py
+++ b/pyplecs/mcp/plecs_tools.py
@@ -44,13 +44,19 @@ def plecs_search(query: str) -> str:
 
 
 def plecs_xml(element: str) -> str:
-    """Look up a `.plecs` XML element in plecs-xml-grammar.md."""
+    """Look up a `.plecs` element in plecs-xml-grammar.md.
+
+    `.plecs` files use a Tcl-ish curly-brace key-value format, not XML.
+    The grammar table documents elements as backtick-wrapped tokens
+    (e.g. ``Component { ... }``, ``Type <atom>``). Match those forms.
+    """
     text = _read_ref("plecs-xml-grammar.md")
-    pattern = re.compile(rf"`<{re.escape(element)}\b.*", re.IGNORECASE)
+    esc = re.escape(element)
+    pattern = re.compile(rf"`{esc}\b[^`]*`", re.IGNORECASE)
     matches = pattern.findall(text)
     if matches:
         return "\n".join(matches[:10])
-    return f"element `<{element}>` not documented; try plecs_url('xml-grammar')"
+    return f"element `{element}` not documented; try plecs_url('xml-grammar')"
 
 
 def plecs_url(topic: str) -> str:
@@ -84,9 +90,25 @@ def pyplecs_rpc_surface() -> list[str]:
 
 
 def plecs_component(name: str) -> dict[str, Any]:
-    """Composed: pyplecs wrapper if present, else search references/components/."""
+    """Composed: pyplecs wrapper if present, else search references/components/.
+
+    Match priority:
+      1. exact match against `<Name>PlecsMdl` (case-insensitive on stem)
+      2. substring match, but only when `name` is at least 3 chars
+         (avoids `name="r"` matching every wrapper containing the letter)
+    """
     wrappers = pyplecs_wrappers()
-    matched_wrapper = next((w for w in wrappers if name.lower() in w.lower()), None)
+    needle = name.lower()
+    exact = next(
+        (w for w in wrappers if w.lower().removesuffix("plecsmdl") == needle),
+        None,
+    )
+    if exact is not None:
+        matched_wrapper: str | None = exact
+    elif len(needle) >= 3:
+        matched_wrapper = next((w for w in wrappers if needle in w.lower()), None)
+    else:
+        matched_wrapper = None
     body = {
         "name": name,
         "pyplecs_wrapper": matched_wrapper,

--- a/pyplecs/mcp/server.py
+++ b/pyplecs/mcp/server.py
@@ -1,0 +1,73 @@
+"""Stdio MCP server exposing the plecs-expert tools."""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from .plecs_tools import TOOL_REGISTRY
+
+
+def _to_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, indent=2, default=str)
+
+
+def build_server() -> Server:
+    server: Server = Server("pyplecs-mcp")
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name=name,
+                description=(fn.__doc__ or name).strip().splitlines()[0],
+                inputSchema={
+                    "type": "object",
+                    "properties": {"argument": {"type": "string"}},
+                    "required": [],
+                },
+            )
+            for name, fn in TOOL_REGISTRY.items()
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        fn = TOOL_REGISTRY.get(name)
+        if fn is None:
+            return [TextContent(type="text", text=f"unknown tool: {name}")]
+        arg = arguments.get("argument", "")
+        try:
+            result = fn(arg) if arg else fn()
+        except TypeError:
+            result = fn()
+        return [TextContent(type="text", text=_to_text(result))]
+
+    return server
+
+
+async def _serve() -> None:
+    server = build_server()
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+def main() -> int:
+    try:
+        asyncio.run(_serve())
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:
+        print(f"pyplecs-mcp error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyplecs/mcp/server.py
+++ b/pyplecs/mcp/server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import sys
 from typing import Any
@@ -42,11 +43,22 @@ def build_server() -> Server:
         fn = TOOL_REGISTRY.get(name)
         if fn is None:
             return [TextContent(type="text", text=f"unknown tool: {name}")]
+        sig = inspect.signature(fn)
+        required_params = [
+            p for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+            and p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.POSITIONAL_ONLY)
+        ]
         arg = arguments.get("argument", "")
+        if required_params and not arg:
+            return [TextContent(
+                type="text",
+                text=f"tool '{name}' requires an 'argument' string",
+            )]
         try:
-            result = fn(arg) if arg else fn()
-        except TypeError:
-            result = fn()
+            result = fn(arg) if required_params else fn()
+        except Exception as exc:  # surface real errors as text rather than crashing the loop
+            return [TextContent(type="text", text=f"tool '{name}' error: {exc}")]
         return [TextContent(type="text", text=_to_text(result))]
 
     return server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ include = ["pyplecs*"]
 pyplecs-api = "pyplecs.api:main"
 pyplecs-setup = "pyplecs.cli.installer:main"
 pyplecs-gui = "pyplecs.webgui:run_app"
+pyplecs-mcp = "pyplecs.mcp:main"
 
 [tool.ruff]
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,11 @@ web = [
     "rich>=10.0.0",
     "tqdm>=4.62.0",
 ]
+mcp = ["mcp>=1.0"]
 dev = [
     "beautifulsoup4>=4.12",
     "httpx>=0.25",
+    "mcp>=1.0",
     "pytest",
     "ruff",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ web = [
     "tqdm>=4.62.0",
 ]
 dev = [
+    "beautifulsoup4>=4.12",
+    "httpx>=0.25",
     "pytest",
     "ruff",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pyplecs-gui = "pyplecs.webgui:run_app"
 pyplecs-mcp = "pyplecs.mcp:main"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -118,3 +118,11 @@ def test_caveman_compliance():
                 if word in tokens:
                     failures.append(f"{md.relative_to(SKILL_ROOT)}:{line_no} banned: {word}")
     assert not failures, "\n".join(failures)
+
+
+def test_slash_command_routes():
+    """The /plecs slash command exists and routes to the plecs-expert skill."""
+    cmd = SKILL_ROOT.parent.parent / "commands" / "plecs.md"
+    assert cmd.exists(), f"missing: {cmd}"
+    text = cmd.read_text(encoding="utf-8")
+    assert "plecs-expert" in text, "command does not reference the plecs-expert skill"

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -91,8 +91,20 @@ BANNED_WORDS = {
 ALLOW_MARKER = "<!-- caveman:allow -->"
 
 
-def _strip_code_blocks(text: str) -> str:
-    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+def _strip_non_prose(text: str) -> str:
+    """Strip fenced code blocks AND verbatim-table sections from text.
+
+    Verbatim sections (between BEGIN/END VERBATIM TABLE markers) are facts
+    quoted from PLECS docs; they are exempt from caveman-style enforcement.
+    """
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    text = re.sub(
+        r"<!--\s*BEGIN VERBATIM TABLE:.*?<!--\s*END VERBATIM TABLE:.*?-->",
+        "",
+        text,
+        flags=re.DOTALL,
+    )
+    return text
 
 
 def test_caveman_compliance():
@@ -105,7 +117,7 @@ def test_caveman_compliance():
         text = md.read_text(encoding="utf-8")
         if ALLOW_MARKER in text:
             continue
-        prose = _strip_code_blocks(text)
+        prose = _strip_non_prose(text)
         for line_no, line in enumerate(prose.splitlines(), start=1):
             tokens = re.findall(r"\b\w+\b", line.lower())
             for word in BANNED_WORDS:

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -126,3 +126,40 @@ def test_slash_command_routes():
     assert cmd.exists(), f"missing: {cmd}"
     text = cmd.read_text(encoding="utf-8")
     assert "plecs-expert" in text, "command does not reference the plecs-expert skill"
+
+
+EXPECTED_MCP_TOOLS = {
+    "plecs_lookup",
+    "plecs_search",
+    "plecs_xml",
+    "plecs_url",
+    "plecs_component",
+    "plecs_rpc",
+    "pyplecs_wrappers",
+    "pyplecs_rpc_surface",
+}
+
+
+def test_pyplecs_wrappers_introspectable():
+    """pyplecs.plecs_components imports clean and exposes *PlecsMdl classes."""
+    import pyplecs.plecs_components as comps  # noqa: F401
+    from pyplecs.mcp.plecs_tools import pyplecs_wrappers
+
+    wrappers = pyplecs_wrappers()
+    assert wrappers, "no wrapper classes found in pyplecs.plecs_components"
+    assert any(w.endswith("PlecsMdl") for w in wrappers), (
+        f"expected *PlecsMdl naming convention; got: {wrappers}"
+    )
+
+
+def test_mcp_tools_register():
+    """Importing pyplecs.mcp.plecs_tools exposes the expected 8 tools."""
+    from pyplecs.mcp.plecs_tools import TOOL_REGISTRY
+
+    assert set(TOOL_REGISTRY) == EXPECTED_MCP_TOOLS, (
+        f"tool registry mismatch: extra={set(TOOL_REGISTRY) - EXPECTED_MCP_TOOLS} "
+        f"missing={EXPECTED_MCP_TOOLS - set(TOOL_REGISTRY)}"
+    )
+    # Each entry is callable
+    for name, fn in TOOL_REGISTRY.items():
+        assert callable(fn), f"{name} not callable"

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -69,3 +69,46 @@ def test_url_index_resolvable():
         if " " in url or url.endswith((".",  ",", ";")):
             failures.append(f"malformed URL: {url}")
     assert not failures, "\n".join(failures)
+
+
+BANNED_WORDS = {
+    # caveman methodology — drop articles, fillers, hedging.
+    # We can't strip articles globally without false positives, so the
+    # banned set is just fillers + hedges. See style/caveman.md.
+    "basically",
+    "really",
+    "actually",
+    "essentially",
+    "obviously",
+    "simply",
+    "just",     # ambiguous in code contexts; allow override via marker
+    "very",
+    "quite",
+    "perhaps",
+    "maybe",
+}
+
+ALLOW_MARKER = "<!-- caveman:allow -->"
+
+
+def _strip_code_blocks(text: str) -> str:
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+def test_caveman_compliance():
+    """Rewritten prose in references/*.md must avoid banned filler words."""
+    refs = SKILL_ROOT / "references"
+    if not refs.exists():
+        return
+    failures: list[str] = []
+    for md in _walk_md(refs):
+        text = md.read_text(encoding="utf-8")
+        if ALLOW_MARKER in text:
+            continue
+        prose = _strip_code_blocks(text)
+        for line_no, line in enumerate(prose.splitlines(), start=1):
+            tokens = re.findall(r"\b\w+\b", line.lower())
+            for word in BANNED_WORDS:
+                if word in tokens:
+                    failures.append(f"{md.relative_to(SKILL_ROOT)}:{line_no} banned: {word}")
+    assert not failures, "\n".join(failures)

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -28,8 +28,6 @@ def test_skill_md_under_4kb():
 def test_references_no_dead_links():
     """Every relative link in references/*.md resolves to an existing file."""
     root = SKILL_ROOT / "references"
-    if not root.exists():
-        return  # phase 1 vacuous pass
     failures: list[str] = []
     for md in _walk_md(root):
         text = md.read_text(encoding="utf-8")
@@ -46,8 +44,6 @@ def test_license_notes_complete():
     """Every references/*.md is classified in LICENSE-NOTES.md."""
     notes = SKILL_ROOT / "LICENSE-NOTES.md"
     refs = SKILL_ROOT / "references"
-    if not refs.exists() or not notes.exists():
-        return  # phase 1 vacuous pass
     notes_text = notes.read_text(encoding="utf-8")
     failures: list[str] = []
     for md in _walk_md(refs):
@@ -60,8 +56,6 @@ def test_license_notes_complete():
 def test_url_index_resolvable():
     """URLs in url-index.md are syntactically valid (no fetch)."""
     idx = SKILL_ROOT / "references" / "url-index.md"
-    if not idx.exists():
-        return  # phase 1 vacuous pass
     failures: list[str] = []
     for url in URL_RE.findall(idx.read_text(encoding="utf-8")):
         if "docs.plexim.com" not in url:

--- a/tests/test_plecs_expert.py
+++ b/tests/test_plecs_expert.py
@@ -1,0 +1,71 @@
+"""Tests for the plecs-expert skill (file layout, content, MCP wiring).
+
+Platform-independent: no PLECS instance, no network, no subprocess.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).parent.parent / ".claude" / "skills" / "plecs-expert"
+
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+URL_RE = re.compile(r"https?://[^\s)>\]]+")
+
+
+def _walk_md(root: Path):
+    return sorted(p for p in root.rglob("*.md"))
+
+
+def test_skill_md_under_4kb():
+    """SKILL.md body must be lookup-fast; cap at 4 KB."""
+    skill_md = SKILL_ROOT / "SKILL.md"
+    assert skill_md.exists(), f"missing: {skill_md}"
+    size = skill_md.stat().st_size
+    assert size <= 4096, f"SKILL.md is {size} bytes (limit 4096)"
+
+
+def test_references_no_dead_links():
+    """Every relative link in references/*.md resolves to an existing file."""
+    root = SKILL_ROOT / "references"
+    if not root.exists():
+        return  # phase 1 vacuous pass
+    failures: list[str] = []
+    for md in _walk_md(root):
+        text = md.read_text(encoding="utf-8")
+        for target in MD_LINK_RE.findall(text):
+            if target.startswith(("http://", "https://", "#")):
+                continue
+            target_path = (md.parent / target.split("#", 1)[0]).resolve()
+            if not target_path.exists():
+                failures.append(f"{md}: dead link → {target}")
+    assert not failures, "\n".join(failures)
+
+
+def test_license_notes_complete():
+    """Every references/*.md is classified in LICENSE-NOTES.md."""
+    notes = SKILL_ROOT / "LICENSE-NOTES.md"
+    refs = SKILL_ROOT / "references"
+    if not refs.exists() or not notes.exists():
+        return  # phase 1 vacuous pass
+    notes_text = notes.read_text(encoding="utf-8")
+    failures: list[str] = []
+    for md in _walk_md(refs):
+        rel = md.relative_to(SKILL_ROOT).as_posix()
+        if rel not in notes_text:
+            failures.append(f"{rel} not listed in LICENSE-NOTES.md")
+    assert not failures, "\n".join(failures)
+
+
+def test_url_index_resolvable():
+    """URLs in url-index.md are syntactically valid (no fetch)."""
+    idx = SKILL_ROOT / "references" / "url-index.md"
+    if not idx.exists():
+        return  # phase 1 vacuous pass
+    failures: list[str] = []
+    for url in URL_RE.findall(idx.read_text(encoding="utf-8")):
+        if "docs.plexim.com" not in url:
+            continue
+        if " " in url or url.endswith((".",  ",", ";")):
+            failures.append(f"malformed URL: {url}")
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary
- Add `plecs-expert` Claude Code skill at `.claude/skills/plecs-expert/`, grounded in `docs.plexim.com/plecs/latest/`
- Triple delivery: Claude Code skill, `/plecs` slash command (`.claude/commands/plecs.md`), `pyplecs-mcp` stdio MCP server
- Two-layer composition: offline references (verbatim factual tables + caveman-style rewritten prose) + live `pyplecs` introspection
- Refresh tooling (`sync_tables.py`, `check_drift.py`, `REFRESH.md`) and 8 platform-independent tests
- Spec: `docs/superpowers/specs/2026-04-27-plecs-expert-skill-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-plecs-expert-skill.md`

Closes #23.

## What's in `.claude/skills/plecs-expert/`
- `SKILL.md` (under 4 KB, lookup-fast)
- 13 reference files (8 component families + rpc-api + plecs-xml-grammar + solver + codegen + cscript + url-index)
- `style/caveman.md` style rules + banned-words list
- `LICENSE-NOTES.md` per-file verbatim/rewritten classification
- `manifest.json` source-URL → hash map + pyplecs introspection snapshot
- `tools/` — sync_tables.py, check_drift.py, REFRESH.md (refresh procedure)

## What's in `pyplecs/mcp/`
- `plecs_tools.py` — 8 read-only tools (plecs_lookup, plecs_search, plecs_xml, plecs_url, plecs_component, plecs_rpc, pyplecs_wrappers, pyplecs_rpc_surface)
- `server.py` — stdio MCP server using `mcp>=1.0` SDK
- `__init__.py` exposes `create_mcp_server()` and `main()`
- `pyproject.toml` registers `pyplecs-mcp` console script + `mcp` extra

## Test plan
- [x] `ruff check .` clean
- [x] `pytest tests/test_plecs_expert.py` — 8/8 pass
- [x] Pre-push hook (ruff + vulture + 5 platform-independent test files) green
- [x] `pyplecs-mcp` constructs; 8 tools register
- [x] `plecs_component("Inductor")` returns `InductorPlecsMdl` + real docs grounding from `references/components/electrical-passive.md`
- [ ] Manual: register `pyplecs-mcp` in Claude Desktop and exercise end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)