### PR TITLE
chore(gitignore): exclude local PLECS samples + articles/output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,14 @@ utils/
 .claude/
 
 docs/articles/diagrams/output/
+docs/articles/output/
 FORCE_PUSH_PLAN.txt
+
+# Local PLECS sample experiments (canonical samples like simple_buck_prb.plecs
+# stay tracked; this rule only affects new untracked .plecs / .plecs.bak / .m files)
+data/*.plecs*
+data/*.m
+data/*.csv
 
 # Build artifacts
 site/


### PR DESCRIPTION
## Summary
- `data/*.plecs*` — local experimental schematics + PLECS autosaves. Canonical samples already tracked (`simple_buck_prb.plecs` etc.) remain tracked; gitignore only affects future / currently-untracked files.
- `data/*.m`, `data/*.csv` — companion MATLAB scripts and CSV outputs from local experiments.
- `docs/articles/output/` — sibling to the already-ignored `docs/articles/diagrams/output/`.

Reduces `git status` noise from ~23 untracked files to ~2.

## Test plan
- [x] `git status` post-change shows only relevant pending files
- [x] Pre-push hook (ruff + vulture + 5 platform-independent test files) green
- [x] No tracked files affected (gitignore is silent on already-tracked paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)