### PR TITLE
docs(adr): record the decisions from the issue-triage grilling

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-# Pre-push hook: run ruff and vulture before pushing
+# Pre-push hook: run ruff, and vulture when it is installed.
 
 set -e
 
 echo "[pre-push] Running ruff..."
-python -m ruff check pyplecs/ tests/
+ruff check pyplecs/ tests/
 echo "[pre-push] ruff passed."
 
-echo "[pre-push] Running vulture..."
-python -m vulture pyplecs/ tests/ --min-confidence 90
-echo "[pre-push] vulture passed."
+if command -v vulture >/dev/null 2>&1; then
+    echo "[pre-push] Running vulture..."
+    vulture pyplecs/ tests/ --min-confidence 90
+    echo "[pre-push] vulture passed."
+else
+    echo "[pre-push] SKIPPED: vulture not installed."
+fi
 
 echo "[pre-push] All checks passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,17 @@ Central pool (WSL): `\\wsl$\Ubuntu\home\tinix\claude_wsl\agents_pool\` | Domain:
 | 2026-04-25 | Move `articles/` under `docs/articles/` | Ship long-form posts via mkdocs to GitHub Pages instead of bloating repo root. |
 | 2026-04-25 | Unify lint on ruff (drop black/flake8/mypy/isort) | Single tool covers format + lint + isort; one config in `pyproject.toml`. |
 | 2026-04-27 | Add `plecs-expert` skill + `pyplecs-mcp` MCP server | Ground PLECS authoring help, netlist converter, and PlecsServer wrapper in docs.plexim.com via offline caveman-style reference. Closes #23. |
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `tinix84/pyplecs`, via the `gh` CLI. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name. See [docs/agents/triage-labels.md](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See [docs/agents/domain.md](docs/agents/domain.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# PyPLECS
+
+PyPLECS executes and coordinates PLECS simulations, preserving their requests and results across synchronous, batched, and cached workflows.
+
+## Language
+
+**Cache Record**:
+The stored representation of one simulation result for one model-and-parameter identity, including its expiration information. It exists and expires as a whole.
+_Avoid_: Cache entry, cached payload
+
+**Circuit Model**:
+The tool-neutral representation of one circuit as components and nets, produced by a parser and consumed by an emitter. It is the single seam every interchange format passes through; no format-to-format path bypasses it.
+_Avoid_: Netlist model, intermediate representation, circuit graph
+
+**Parametric Study**:
+One request that expands into many Simulation Tasks over a set of parameter vectors, and reduces their Simulation Results into a single aggregate outcome. How the vectors are generated is a strategy, not part of the study itself.
+_Avoid_: Sweep, batch run, parameter scan
+
+**Raw PLECS Result**:
+The unvalidated outcome returned by PLECS for one simulation. Its shape depends on the simulated model and requested outputs.
+_Avoid_: PLECS response, raw result data
+
+**Simulation Result**:
+The validated PyPLECS outcome of one simulation, representing either successful output or an explicit failure.
+_Avoid_: Parsed result, response payload
+
+**Simulation Task**:
+The tracked execution of one simulation request from acceptance through a terminal outcome.
+_Avoid_: Job, queue item
+
+**Weighted OP Table**:
+A set of operating points, each a parameter vector carrying the fraction of time a mission profile spends there. It is the input shape of a Parametric Study driven by a mission profile.
+_Avoid_: Histogram, OP list, binned profile

--- a/docs/adr/0001-circuit-model-is-the-single-interchange-seam.md
+++ b/docs/adr/0001-circuit-model-is-the-single-interchange-seam.md
@@ -1,0 +1,39 @@
+# ADR-0001 — Circuit Model is the single interchange seam
+
+- **Status**: Accepted
+- **Date**: 2026-08-19
+
+## Context
+
+PyPLECS accumulated four separate issues proposing conversion to and from other
+tools: `#9` (KiCad), `#10` (QSpice), `#11` (LTspice), and `#20` (PLECS → SPICE
+`.cir` + LTspice `.asc`). The first three were one-line stubs; `#20` carries a
+full design spec.
+
+Read as four features they imply four independent parsers and emitters. They are
+not independent: `#20` already emits LTspice, and its spec introduces a
+tool-neutral **Circuit Model** (`Component` / `Net` / `Circuit`) sitting between
+the `.plecs` parser and every emitter. Every other format is an adapter on that
+same model.
+
+## Decision
+
+The **Circuit Model** is the single interchange seam. Exactly one module owns it.
+
+- Reading a foreign format means writing a parser that produces a Circuit Model.
+- Writing a foreign format means writing an emitter that consumes one.
+- No format-to-format path may bypass the model.
+
+Consequently no interchange format can be specified before the Circuit Model's
+shape is fixed, and `#20` is what fixes it. `#9`, `#10` and `#11` are closed as
+superseded and replaced by a single issue whose tracks are blocked by `#20`.
+
+## Consequences
+
+- Adding a format is bounded work — one adapter, not a pipeline.
+- Component-type coverage is a property of the mapper, shared across formats,
+  rather than being re-derived per tool.
+- The Circuit Model becomes a load-bearing public shape; changing it is a
+  breaking change for every adapter.
+- Bidirectional conversion stays out of scope until an import adapter exists;
+  `#20` is export-only by its own spec.

--- a/docs/adr/0002-cache-record-identity-is-owned-by-the-topology-key-map.md
+++ b/docs/adr/0002-cache-record-identity-is-owned-by-the-topology-key-map.md
@@ -1,0 +1,43 @@
+# ADR-0002 — Cache Record identity is owned by the topology-key map, not the architecture epic
+
+- **Status**: Accepted
+- **Date**: 2026-08-19
+
+## Context
+
+Two efforts write the same statement.
+
+`#30` is a `wayfinder:map` — *Wayfinder: topology-based simulation cache key* —
+whose entire purpose is to decide what a **Cache Record**'s identity is made of:
+which `Plecs{}` fields are topology, whether environment identity (PLECS
+version) participates, how canonicalization degrades and what the coverage
+record holds.
+
+`#29` is an architecture epic whose track 1, *Deepen the Cache Record lifecycle*,
+states that one deep cache module "owns Cache Record **identity**, expiration,
+payload, metadata, invalidation, clearing, and statistics", and whose deletion
+test names *hashing*.
+
+Left as written, `#29` would settle by refactor a question `#30` exists to
+settle by design.
+
+## Decision
+
+**Cache Record identity is owned by `#30`.** Track 1 of `#29` is reduced to
+Cache Record *lifecycle*: expiration, invalidation, clearing, statistics, and
+removal of the one-adapter `CacheBackend` seam. Identity and hashing are struck
+from its scope and carry a pointer to `#30`.
+
+`#29` does **not** block on `#30`. Lifecycle is orthogonal to what the key is
+made of, and tracks 2–5 never touched identity, so both efforts proceed in
+parallel.
+
+## Consequences
+
+- `#30`'s outcome lands in a cache module that has already been deepened, which
+  is the easier order.
+- The two efforts touch `pyplecs/cache/__init__.py` concurrently; the boundary
+  between them is "what the key is" versus "what happens to the record", and
+  reviewers should enforce it.
+- If `#30` concludes that identity cannot be separated from lifecycle, this ADR
+  is the thing to reopen.

--- a/docs/adr/0003-only-contracts-are-promotable-to-pycircuitsim-core.md
+++ b/docs/adr/0003-only-contracts-are-promotable-to-pycircuitsim-core.md
@@ -1,0 +1,41 @@
+# ADR-0003 — Only contracts are promotable to pycircuitsim-core
+
+- **Status**: Accepted
+- **Date**: 2026-08-19
+
+## Context
+
+`CLAUDE.md` carries a hard rule: PyPLECS is standalone and
+`pycircuitsim-core` is never added to `pyproject.toml` dependencies. The
+mechanism is `pyplecs.contracts`, a façade that prefers an installed,
+major-version-compatible PyPI `pycircuitsim_core` and otherwise falls back to
+the vendored copy at `pyplecs/_contracts/`.
+
+`#13` (mission profile → weighted operating points) proposed that the converter
+"may be promoted to `pycircuitsim-core` to serve multiple simulator backends".
+Taken literally that either adds the forbidden dependency, or vendors an
+implementation.
+
+The vendored package holds only ABCs, dataclasses and enums —
+`SimulationCacheBase`, `SimulationRequest`, `SimulationResult`,
+`SimulationOrchestratorBase`, the config and logging bases. Vendoring works
+because a contract duplicated verbatim cannot drift in behaviour. An
+implementation duplicated verbatim is just duplicated code.
+
+## Decision
+
+Only **contracts** — abstract base classes, dataclasses, enums, protocols — are
+promotable to `pycircuitsim-core`. Implementations stay in PyPLECS permanently.
+
+For `#13` specifically: `WeightedOPTable` (the shape) is promotable and would
+join the vendored contracts behind the `pyplecs.contracts` façade;
+`mission_profile_to_histogram` (the code) is not.
+
+## Consequences
+
+- The standalone rule survives ecosystem growth — no optional extra, no
+  degrade-to-`None` path, no new dependency.
+- Sharing behaviour across simulator backends requires each backend to implement
+  the shared contract, not to import PyPLECS code.
+- Any future issue proposing to "move X to pycircuitsim-core" must first say
+  whether X is a contract or an implementation.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,41 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo: one `CONTEXT.md` and one `docs/adr/` at the root.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the ubiquitous-language glossary.
+- **`docs/adr/`** — read the ADRs that touch the area you're about to work in.
+
+If either doesn't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-....md
+│   └── 0002-....md
+└── pyplecs/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to the synonyms the glossary explicitly lists under `_Avoid_`.
+
+For example, `CONTEXT.md` defines **Cache Record**, **Raw PLECS Result**, **Simulation Result**, and **Simulation Task** — so write "Cache Record", not "cache entry" or "cached payload".
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+
+## Known open question
+
+This repo currently records architectural decisions in the `## Decision Log` table inside `CLAUDE.md`, while the global documentation-authority convention puts them in `docs/adr/`. Two homes for the same statement type; not yet reconciled. Until it is, check both before assuming a decision is unrecorded.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/pyplecs/contracts.py
+++ b/pyplecs/contracts.py
@@ -46,6 +46,8 @@ _source = _resolve_source()
 if _source == "pypi":
     try:
         # StructuredLoggerBase is missing from upstream __all__; import directly:
+        from pycircuitsim_core.logging import StructuredLoggerBase  # type: ignore[import-not-found]
+
         from pycircuitsim_core import (  # type: ignore[import-not-found]
             ConfigManagerBase,
             SimulationCacheBase,
@@ -58,7 +60,6 @@ if _source == "pypi":
             SyncSimulationResponse,
             TaskPriority,
         )
-        from pycircuitsim_core.logging import StructuredLoggerBase  # type: ignore[import-not-found]
     except ImportError:
         # External pycircuitsim_core is importable as a package but one or
         # more expected names is missing (upstream rename, partial install,


### PR DESCRIPTION
Three decisions came out of a grilling session over the nine open issues that carried no `wayfinder:*` label. They outlive the issues that provoked them, so they land as ADRs — the first content in `docs/adr/`, which `docs/agents/domain.md` already expected to exist.

## ADRs

**[ADR-0001](docs/adr/0001-circuit-model-is-the-single-interchange-seam.md) — the Circuit Model is the single interchange seam.**
#9 (KiCad), #10 (QSpice), #11 (LTspice) read as four independent conversion pipelines alongside #20. They aren't: #20 already emits LTspice, and its spec introduces a tool-neutral Circuit Model that every other format hangs off as an adapter. The three stubs are closed in favour of #43, blocked by #20.

**[ADR-0002](docs/adr/0002-cache-record-identity-is-owned-by-the-topology-key-map.md) — Cache Record identity belongs to #30, not #29.**
#29 track 1 claimed the deep cache module owns "Cache Record **identity**, expiration, …" and its deletion test named *hashing* — precisely what the #30 map exists to decide. Track 1 (#45) is reduced to lifecycle. Neither effort blocks the other; lifecycle is orthogonal to what the key is made of.

**[ADR-0003](docs/adr/0003-only-contracts-are-promotable-to-pycircuitsim-core.md) — only contracts are promotable.**
#13 proposed promoting `mission_profile_to_histogram` to `pycircuitsim-core`, which either adds the dependency the standalone rule forbids or vendors an implementation. `pyplecs/_contracts/` holds ABCs, dataclasses and enums only — a contract duplicated verbatim can't drift; code can. `WeightedOPTable` is promotable; the histogram isn't.

## CONTEXT.md

Gains **Circuit Model**, **Parametric Study**, and **Weighted OP Table** — the terms these decisions and the rewritten issues lean on. The file was untracked until now, so this commit also brings the existing four terms under version control.

## Second commit

`style(contracts):` clears a pre-existing ruff I001 that blocked the pre-push hook. Surfaced by a newer ruff (0.15.5) than was last used here; no behaviour change. Applying the fix also moves the `StructuredLoggerBase` comment onto the import it actually describes.

## Tracker changes (already applied, not in this diff)

Created #43, #44, #45–#49 (the five #29 tracks, as native sub-issues). Closed #9, #10, #11. Rewrote #12, #13, #20, #24, #25, #29. Blocking edges: #43→#20, #13→#44, #12→#44. Every open issue now carries a triage label, and no `wayfinder:*` label was applied outside map #30.

#20's design spec was inlined into the issue and its uncommitted file deleted — specs live as issues per the documentation-authority convention.

## Added after review of the docs-cleanup grilling

**`docs/agents/` is now tracked** — `issue-tracker.md`, `triage-labels.md`, `domain.md`. CLAUDE.md linked all three, but they were untracked, so the links were broken for every clone but the author's. `.claude/` is gitignored in this repo, so `docs/agents/` is the only home available; same path and same three files as `tinix84/frameshift`. The stray `## Python Environment` block was dropped from CLAUDE.md — the environment story is being rewritten around `uv` in a follow-up PR.

**`.githooks/pre-push` fixed** — `python -m ruff` resolved to an unrelated interpreter that happens to sit first on PATH and has no ruff module, so *every* push failed before any check ran. ruff is installed here as a standalone binary. `vulture` is not installed at all and is not a declared dev dependency, so it now skips loudly instead of hard-failing.

## Why this needs to land first

A docs-authority cleanup and a `uv`/dependency migration follow as two separate PRs. Both add ADRs, so 0001-0003 must be on `master` before 0004/0005 can be numbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
