### PR TITLE
docs(research): rescue two findings from branches about to be deleted

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,23 @@
 
 set -e
 
+# Deleting a branch pushes only zero-sha refs. Linting and testing the local
+# working tree tells us nothing about a deletion, so skip the gate entirely --
+# otherwise removing six merged branches costs six full test runs.
+all_deletions=1
+saw_ref=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    [ -z "$local_sha" ] && continue
+    saw_ref=1
+    case "$local_sha" in
+        *[!0]*) all_deletions=0 ;;
+    esac
+done
+if [ "$saw_ref" = 1 ] && [ "$all_deletions" = 1 ]; then
+    echo "[pre-push] deletion-only push; skipping checks."
+    exit 0
+fi
+
 PYTEST_FILES=(
     tests/test_installer.py
     tests/test_entrypoint.py

--- a/docs/research/2026-08-19-offline-symbol-resolution.md
+++ b/docs/research/2026-08-19-offline-symbol-resolution.md
@@ -1,0 +1,126 @@
+# Research: How far can symbols and InitializationCommands be resolved offline?
+
+**Ticket**: [tinix84/pyplecs#33](https://github.com/tinix84/pyplecs/issues/33), part of the [wayfinder map #30](https://github.com/tinix84/pyplecs/issues/30) (topology-based simulation cache key).
+**Governing invariant** (from #30): the key never claims equality it cannot prove; unrecognised constructs degrade to normalized-byte inclusion, never fail open.
+**Date**: 2026-08-19
+
+## Corpus note (discrepancy from ticket premise)
+
+The ticket and parent map assume "the 25 models in `data/*.plecs`." At `research/offline-symbol-resolution` (branch cut from `master`), `data/*.plecs` contains **5 files**, not 25:
+
+- `data/fb_src_prb.plecs` (1103 lines)
+- `data/simple_boost_prb.plecs` (626 lines)
+- `data/simple_buck_prb.plecs` (580 lines)
+- `data/simple_buckboost_prb.plecs` (627 lines)
+- `data/simple_nibb_prb.plecs` (970 lines)
+
+`git log --all --diff-filter=A -- 'data/*.plecs'` shows only two additional historical filenames (`data/01/simple_buck01.plecs`, `data/02/simple_buck02.plecs`, `data/simple_buck.plecs`) that no longer exist in the working tree. The repo's `.gitignore` (added in #28, "chore(gitignore): exclude local PLECS samples") ignores new untracked `data/*.plecs*` going forward, so any additional samples a contributor drops in locally will not be visible to future research either. **All findings below are evidenced against these 5 files**; conclusions about "what the corpus contains" should be read as "what these 5 tracked models contain," not a 25-model sample. This gap itself argues for the conservative degrade path (map decision 6): a canonicalizer sized to this corpus's construct set will hit unfamiliar constructs the moment richer models are added, and must degrade to byte-inclusion rather than mis-resolve them.
+
+## Q1 — Precedence: InitializationCommands vs ModelVars
+
+**Source**: `.claude/skills/plecs-expert/references/rpc-api.md` (offline reference), sourced from `https://docs.plexim.com/plecs/latest/scripting/`.
+
+Verbatim from the `ModelVars` row of PLECS's scripted-simulation options table:
+
+> "The optional field `ModelVars` is a struct variable that allows you to override variable values defined by the model initialization commands... **The override values are applied after the model initialization commands have been evaluated and before the component parameters are evaluated**, as shown in Fig. 117."
+
+This resolves the question directly:
+
+- **Order of evaluation**: (1) `InitializationCommands` runs in the model workspace → (2) `ModelVars` overrides are applied to that workspace → (3) component `Value` expressions (e.g. `"Lo"`) are evaluated by looking up identifiers in that workspace.
+- **Which wins on a name collision**: `ModelVars` wins — it is applied strictly after `InitializationCommands`, so a `ModelVars` entry overwrites any same-named variable the init script set.
+- **Is the init script aware of ModelVars?** No. Because the override step happens after the init script has already finished evaluating, `InitializationCommands` cannot observe or branch on `ModelVars` values (e.g. it cannot compute `derived = Vi_override * 2` reflecting an override — `Vi_override` does not exist yet when the init script runs).
+
+This maps cleanly onto map decision 4's `topology_id`/`params_id` split: `params_id` should record the *post-override* workspace value (what the component parameter actually resolved to), and the resolution pipeline must apply `ModelVars` strictly after simulating the init script's side effects — matching `pyplecs/pyplecs.py:355` (`dict_to_plecs_opts` wraps a params dict as `{"ModelVars": varin}`) and the call at `pyplecs/pyplecs.py:356` (`self.server.plecs.simulate(self.modelName, opts)`), which hands this struct to PLECS over XML-RPC exactly as the docs describe.
+
+Confirmed by direct file evidence in the corpus's `InitializationCommands` string (identical pattern in all 5 files, e.g. `data/simple_buck_prb.plecs:26`):
+
+```
+InitializationCommands "%% input\nT_sim = 1e-3; % simulation time\ndt = 1e-6"
+```
+
+`T_sim` and `dt` are set here; they are never present as `ModelVars` in any test or example in this repo — consistent with them being simulation-scaffolding constants rather than swept design parameters.
+
+## Q2 — Where symbols come from
+
+**Direct file evidence**, `data/simple_buck_prb.plecs`: the `InitializationCommands` block (line 26) only ever assigns `T_sim` and `dt`. Every electrical/control component parameter is a bare symbolic string, not a literal:
+
+```
+data/simple_buck_prb.plecs:74:   Value "Vi"
+data/simple_buck_prb.plecs:88:   Value "Ro"
+data/simple_buck_prb.plecs:102:  Value "Lo"
+data/simple_buck_prb.plecs:121:  Value "Co"
+data/simple_buck_prb.plecs:126:  Value "Vo_ref"
+data/simple_buck_prb.plecs:140:  Value "Vf_d"
+data/simple_buck_prb.plecs:145:  Value "Ron_d"
+data/simple_buck_prb.plecs:174:  Value "ron"
+data/simple_buck_prb.plecs:218:  Value "fs"
+data/simple_buck_prb.plecs:223:  Value "D"
+data/simple_buck_prb.plecs:426:  Value "Ii_max"
+```
+
+None of `Vi, Ro, Lo, Co, Vo_ref, Vf_d, Ron_d, ron, fs, D, Ii_max` are ever assigned inside any `InitializationCommands` in the corpus (verified across all 5 files — the `InitializationCommands` string is byte-identical in shape across all of them, only ever touching `T_sim`/`dt`). **Confirmed**: these symbols arrive exclusively via `ModelVars` at `simulate()`-call time (`pyplecs/pyplecs.py:335-356`), not via the model file itself. This is the intended pattern per Q1's evaluation order — it is also the *only* pattern evidenced in this corpus; there is no example of a symbol being bound by `InitializationCommands` instead of `ModelVars`.
+
+**What happens if a symbol is bound nowhere — not resolvable offline.** `WebFetch` against `https://docs.plexim.com/plecs/latest/scripting/` (the same page backing Q1) was asked directly whether PLECS raises an error or silently defaults when a component parameter references an undefined variable. Result: **the documentation does not state this.** This is a genuine gap — not a memory-recall shortcut avoided, but an honest "the primary source is silent here." It should feed the conservative degrade path (map decision 6): the canonicalizer cannot assume unresolved symbols simulate successfully (or fail loudly) without a live PLECS/MATLAB check; treat an unbound symbol as unresolved (byte-degrade that component's parameter binding) rather than guessing PLECS's runtime behavior.
+
+## Q3 — Expression language actually present in the corpus
+
+Enumerated directly from all 5 files (`grep -n "InitializationCommands"` plus a scan of every `Value` field with a symbolic or numeric literal):
+
+**`InitializationCommands` constructs found** (identical construct set in all 5 files, only literal values differ):
+- `%%` cell-marker comment (`%% input`)
+- `%` trailing line comment (`% simulation time`)
+- Plain scalar assignment (`T_sim = 1e-3`, `dt = 1e-6`)
+- Scientific-notation numeric literals (`1e-3`, `1e-6`, `1`)
+- Semicolon statement suppression — **inconsistently applied**: `simple_buck_prb.plecs` omits the trailing `;` after `dt`'s assignment; the other four files include it (with a trailing space after). This is itself evidence that PLECS tolerates a missing trailing semicolon/newline at the end of the script.
+
+**Constructs NOT found in any `InitializationCommands` in the corpus**: vectors/matrices (`[...]`), function calls, conditionals (`if`), loops (`for`/`while`), string literals, cell arrays, multi-statement chains beyond the two assignments shown above.
+
+**`Value` field constructs found** (checked across all 5 files with `grep -nE 'Value\s+"[^"]*[*/+()].*"'`, which matched **zero** lines in any file):
+- Bare symbolic identifiers only, e.g. `"Vi"`, `"Lo"`, `"Vo_ref"`, `"Ron_d"`, `"Ii_max"` (mixed case, underscores)
+- Plain numeric literals: `"0"`, `"1"`, `"-1"`, `"4"`, `"10"`, `"3"`
+- One empty string `Value ""` (`data/simple_nibb_prb.plecs:439`) — belongs to a non-electrical/meta field, not an evaluated component parameter expression
+
+**Not found in any `Value` field in the corpus**: arithmetic expressions (`*`, `/`, `+`, parenthesized sub-expressions), function calls, vectors, conditionals. The corpus's expression surface is narrower than MATLAB/Octave's full grammar — it only exercises "bare identifier" or "bare numeric literal," never a computed expression.
+
+**Caveat**: this describes what these 5 files exercise, not what PLECS's `Value`/`InitializationCommands` grammar *permits*. PLECS's own scripting reference (`.claude/skills/plecs-expert/references/components/system.md`, sourced from `https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/`) documents mask "Edit" parameters as accepting arbitrary MATLAB/Octave expressions evaluated at simulation start, and Lua control structures (`if/then/else`, `for`) for mask icon-drawing scripts (a different, non-simulation-affecting language) — so the ceiling for what a canonicalizer must eventually cope with is broader than this corpus samples, even though this corpus never exercises it.
+
+## Q4 — Feasible offline subset (recommendation)
+
+Given Q3's evidence, the offline-evaluable-without-MATLAB subset that actually matters for the *current* corpus is narrow and safe to hand-parse:
+
+- Recognize and evaluate: numeric literals (incl. scientific notation), bare identifier references, `%`/`%%` comment stripping, optional trailing `;`.
+- Everything else (arithmetic expressions, function calls, vectors, conditionals, `for`/`while`) is **out of scope for a hand-rolled offline evaluator** — MATLAB/Octave semantics (operator precedence, broadcasting, built-in function library) are not something to reimplement piecemeal without risking a silent wrong answer, which the governing invariant explicitly forbids ("the key never claims equality it cannot prove").
+
+**Recommended boundary**: parse `InitializationCommands` far enough to (a) strip comments/cell markers and (b) extract `identifier = <literal-or-simple-arithmetic>` assignments where the right-hand side is itself only literals/previously-bound identifiers with `+ - * /`, treating anything that doesn't match that shape (function calls, vectors, conditionals, unrecognized operators) as an opaque, byte-included region per the map's degrade path. This boundary happens to cover 100% of what this corpus contains today, while explicitly failing closed (not open) on the richer constructs the docs confirm PLECS actually permits.
+
+## Q5 — Scope resolution into Subsystem interiors
+
+**Corpus check first**: none of the 5 tracked models contain a `Subsystem` block at all (`grep -c Subsystem` returns `0` for every file). This is a second corpus gap: the Merkle-hierarchy design (map decision 5, "each `Subsystem` canonicalizes to its own `topology_id`") has **zero direct file evidence** to validate against in this repo today. Everything below is therefore sourced from PLECS's own docs, not from repo evidence.
+
+**Masked subsystems — confirmed, with exact citation.** `WebFetch` on `https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/` returned this verbatim:
+
+> **Variable Scope**: "PLECS associates a local variable workspace with each masked subsystem that has one or more mask parameters defined. Components in the underlying schematics can access only variables that are defined in this mask workspace."
+>
+> **Initialization Commands**: "Mask initialization commands are defined on the Initialization pane. They are evaluated in the mask workspace when a simulation is started." ... "Variables defined in the base workspace cannot be accessed."
+
+So for a **masked** subsystem: it has its own isolated mask workspace, populated by its own mask parameters and mask-level `InitializationCommands`; a top-level `ModelVars` entry does **not** reach a symbol used inside a masked subsystem's interior unless that symbol is re-exposed as one of the subsystem's own mask parameters. This directly affects map decision 4/5: `topology_id` for a masked subsystem cannot assume the parent's `params_id` bindings apply inside it — the mask boundary is a hard scope wall, and the Merkle child's `params_id` must be resolved from its own mask workspace, not inherited.
+
+**Plain (unmasked) subsystems — not resolvable offline.** The same fetch explicitly reported: "The documentation does not discuss what happens to variable scope in unmasked (plain) subsystems... There is no comparative discussion between masked versus unmasked subsystem behavior." A second, independent fetch against `https://docs.plexim.com/plecs/latest/scripting/` for the general execution-order question likewise surfaced only the `CurrentComponent`/`CurrentCircuit` special-variable substitution rule (a leading `.` in a component path resolves to "the component currently being evaluated" during mask/model init, or the model itself during model init) — nothing about whether an unmasked subsystem's interior shares its parent's base workspace by default.
+
+**This is the honest degrade-path case for Q5**: whether an unmasked `Subsystem`'s interior components resolve symbols against the *parent* model's workspace (i.e., no scope wall unless masked) is not stated anywhere found in the offline reference or the two docs.plexim.com pages fetched, and there is no PLECS instance available to test it empirically in this task. Recommendation: the canonicalizer should **not assume** unmasked subsystems inherit the parent workspace transparently; per the governing invariant, treat symbol resolution across an unmasked-subsystem boundary as unproven until either (a) a live-PLECS test confirms the behavior, or (b) a docs.plexim.com page is found that states it explicitly. Until then, degrade that boundary to byte-inclusion rather than assuming pass-through scoping.
+
+## Summary of what feeds the conservative degrade path (map decision 6)
+
+1. **Undefined-symbol runtime behavior** (Q2) — docs.plexim.com's scripting page does not state whether PLECS errors or silently defaults on an unbound `Value` symbol. Unresolvable offline without a live PLECS instance.
+2. **Full MATLAB/Octave expression grammar** (Q3/Q4) — the corpus only exercises bare literals/identifiers, but PLECS's mask "Edit" parameters accept arbitrary MATLAB/Octave expressions per the docs; a hand-rolled canonicalizer should only claim the literal/identifier/simple-arithmetic subset and degrade everything else.
+3. **Unmasked-subsystem variable scope** (Q5) — masked-subsystem scoping is documented and isolated (confirmed), but plain/unmasked subsystem scoping relative to the parent workspace is not stated in any offline reference or the two docs.plexim.com pages fetched for this ticket, and the corpus contains zero `Subsystem` blocks to test against directly.
+4. **Corpus size mismatch** — the ticket/map's premise of "25 models" does not match the 5 files actually present in `data/*.plecs` at this branch; every finding above is evidenced against those 5, not 25.
+
+## Sources consulted
+
+- `pyplecs/pyplecs.py:52-56` (`dict_to_plecs_opts`), `:335-356` (`simulate`), `:404-414` (`load_modelvars`) — direct repo evidence for the `ModelVars` call path.
+- `data/fb_src_prb.plecs`, `data/simple_boost_prb.plecs`, `data/simple_buck_prb.plecs`, `data/simple_buckboost_prb.plecs`, `data/simple_nibb_prb.plecs` — direct repo evidence, greped for `InitializationCommands`, `Value`, `Subsystem`.
+- `.claude/skills/plecs-expert/references/rpc-api.md` — offline reference, sourced from `https://docs.plexim.com/plecs/latest/scripting/`.
+- `.claude/skills/plecs-expert/references/components/system.md` — offline reference, sourced from `https://docs.plexim.com/plecs/latest/components-by-category/subsystem/`, `.../conf_subsystem/`, and `https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/`.
+- `https://docs.plexim.com/plecs/latest/scripting/` — direct WebFetch (URL fallback), for the undefined-symbol question and the `CurrentComponent`/`CurrentCircuit` scoping rule.
+- `https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/` — direct WebFetch (URL fallback), for masked-subsystem variable scope and initialization commands.

--- a/docs/research/2026-08-19-plecs-reference-semantics.md
+++ b/docs/research/2026-08-19-plecs-reference-semantics.md
@@ -1,0 +1,164 @@
+# PLECS `Reference` block semantics — findings
+
+**Ticket:** [tinix84/pyplecs#34](https://github.com/tinix84/pyplecs/issues/34) — "What does a PLECS Reference block point to, and does its target affect results?"
+**Parent map:** [tinix84/pyplecs#30](https://github.com/tinix84/pyplecs/issues/30) — Wayfinder: topology-based simulation cache key. Governing invariant: *the key never claims equality it cannot prove.*
+**Branch:** `research/plecs-reference-semantics`
+**Date:** 2026-08-19
+
+## Corpus note (read this first)
+
+The parent map states "the 25 models in `data/*.plecs` are the working evidence base." At the time of this research, `git ls-files data/` on `master` shows only **5** tracked `.plecs` files (`fb_src_prb`, `simple_boost_prb`, `simple_buck_prb`, `simple_buckboost_prb`, `simple_nibb_prb`), because `.gitignore` (commit `2e60035`, "exclude local PLECS samples") now ignores `data/*.plecs*` for anything not already tracked. The other 20 files the ticket's "82 occurrences / 25 models" figure depends on are **local, untracked, gitignored** files that exist only in the maintainer's main working copy at `D:\OneDrive\claude\pyplecs\data\` — not in this git worktree, and not in the repository at all from any other clone's point of view.
+
+Counting `^\s*Type\s+Reference\s*$` across that full 25-file local directory gives exactly **82** matches, confirming the ticket's number and letting this research inspect the actual blocks. But this is evidence about the maintainer's local sample set, not about tracked repository content: a fresh clone of `tinix84/pyplecs` has only the 2 `Reference` blocks that live in the tracked `simple_nibb_prb.plecs`. Any canonicalizer/coverage-report design should note that the "82 across `data/*.plecs`" premise describes local fixtures, not the committed corpus — worth flagging back to map issue #30's evidence-base framing.
+
+## 1. What a `Reference` component *is*
+
+A PLECS `Reference` component is **not** a copy of a component's definition. Per docs.plexim.com:
+
+> "When you copy a library component – either into a circuit schematic or into another or even the same component library – PLECS automatically creates a reference component rather than a full copy."
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/
+
+Every one of the 82 blocks in the corpus is this same kind of thing: a **link to a built-in PLECS Component Library entry**, not a user-authored external subsystem and not what PLECS docs separately call a "model reference" (a link to a whole external `.plecs`/Simulink model file — see §6). The block's `SrcComponent` field is the library path, e.g.:
+
+```
+Component {
+  Type          Reference
+  SrcComponent  "Components/Control/Filters/RMS Value"
+  Name          "RMS Value"
+  ...
+  Parameter { Variable "x0" Value "0"  Show off }
+  Parameter { Variable "ts" Value "0"  Show off }
+  Parameter { Variable "fs" Value "fs" Show off }
+  Terminal { Type Input  Position [-15, 0] Direction left }
+  Terminal { Type Output Position [19, 0]  Direction right }
+}
+```
+(`data/simple_nibb_prb.plecs:635-643`, identical structure tracked in both the worktree and main repo copies.)
+
+Fields:
+- `Type Reference` — marks the block as a library-linked component, not an inline primitive.
+- `SrcComponent "<path>"` — the library path the block links to, in the form `Components/<Category>/<Subcategory>/<Component Name>` for every block observed (see §6).
+- `Name` — the instance name in *this* schematic (independent of the library component's own name).
+- `Parameter { Variable ... Value ... Show ... }` — per-instance overrides of the linked component's mask parameters (see §4).
+- `Terminal { ... }` — the block's port geometry, duplicated from the library component so the schematic can render/connect without opening the library.
+
+## 2. How the target is located
+
+> "The reference component links to the library component by its full path, i.e. the Simulink path of the PLECS Library block and the path of the component within the component library as they are in effect at the time the copy is made."
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/
+
+So resolution is by a **library path fixed at copy time**, not a filesystem-relative path stored per-model. If PLECS can't find the library (e.g., a custom/third-party library rather than the shipped standard one), the documented recovery is:
+
+> "In PLECS Blockset, add the directory that contains the required Simulink model to the MATLAB path and reload the circuit."
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/
+
+For the standard `Components/...` library used throughout this corpus, resolution is against PLECS's own bundled Component Library, which ships with the PLECS installation — it is not looked up via a project-relative search path the way `data/*.m`/thermal descriptions can be (a separate, unrelated PLECS Preferences → Thermal tab "description search path" mechanism referenced in code comments inside `bdc_nibb.plecs`, not applicable to `Reference` component resolution).
+
+Separately, for **library link or model reference** subsystems specifically, the offline reference notes relative-path resolution semantics for an unrelated field (mask help HTML), which nonetheless confirms the general rule that reference/link targets resolve relative to *the external source file*, not the referencing model:
+
+> "If the subsystem is a library link or model reference, the relative path is resolved relative to the parent folder of the source library or model file."
+> — `.claude/skills/plecs-expert/references/components/system.md:189`, sourced from https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/
+
+## 3. Copied into the file, or resolved at simulation time?
+
+**Resolved at load time, not embedded at save time.**
+
+> "Library references are resolved upon loading of a model. Afterwards, any changes that you make to a referenced library component are propagated to the referencing components when you start a simulation or when you manually update the simulation model with **Synchronize all external links…**"
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/ (menu path confirmed as **Edit → Synchronize all external links…**)
+
+This is the load-bearing fact for the parent map. The `.plecs` file's `Reference` block stores only the link path, the instance name/position, the per-instance parameter overrides, and terminal geometry — **not** the linked component's internal schematic, equations, or default mask behavior. That internal definition lives in the PLECS Component Library shipped with the installed PLECS version, and PLECS re-resolves and re-propagates it every load and every simulation start.
+
+**Consequence for the cache key (the correctness stake the map cares about):** the byte content of a `.plecs` file does not fully determine simulation results for any model containing a `Reference` block. The PLECS *version* (and, in principle, any non-standard library on the search path) is an external dependency the file's bytes cannot see. Two `.plecs` files with byte-identical `Reference` blocks, simulated under two different installed PLECS versions where Plexim revised the internal implementation of e.g. `Components/Control/Filters/RMS Value`, are not guaranteed to produce identical results — and a cache key computed from file bytes alone would produce a **wrong cache hit** across a PLECS upgrade. This is exactly the failure mode the governing invariant forbids. Whether this is addressed by folding a PLECS version/build identifier into `solver_id` (already a candidate key component per map decision 3) or a dedicated "library resolution" dimension is a decision for the design spec, not this ticket — but the fact that resolution is external and dynamic, not embedded, is established.
+
+## 4. Can a reference be parameterised/masked, and does it follow the symbol-vs-binding split?
+
+Yes to parameterization; masking is inherited, not re-authorable per instance:
+
+> "You can modify the parameters of the reference component but you cannot mask it or, if it is already masked, edit the mask."
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/
+
+So: the *set* of mask parameters (names, types, dialog layout, icon) comes from the library component and cannot be changed per reference instance. The *values* bound to those parameters are per-instance and stored directly on the block, using the identical `Parameter { Variable "<name>" Value "<expr>" Show <on|off> }` structure used by ordinary (non-Reference) components. Corpus evidence, `data/simple_nibb_prb_show.plecs:1683-1766` (`Continuous PID Controller` reference, 15 `Parameter` entries: `cont_type`, `par_source`, `kp`, `ki`, `kd`, `kf`, `ex_reset`, `x0_source`, `x0`, `ex_sat`, `sat_lim`, `up_limit`, `low_limit`, `aw_method`, `kbc`) and `data/simple_nibb_prb.plecs:644-658` (`RMS Value` reference: `Variable "fs" Value "fs"`, i.e. the mask parameter `fs` is bound to a same-named outer-model symbol, not a literal) show `Value` fields holding either literal numbers (`"0"`, `"20"`) or bare symbols (`"fs"`) that resolve against the enclosing model's variables/`InitializationCommands`.
+
+This is the identical `Variable`/`Value` shape the map's decision 4 already assumes for ordinary component parameters (`L1.L <- "Lo"` style symbol binding, `topology_id` records the symbol, `params_id` records the resolved literal). Reference-block parameters need no special-casing in the canonicalizer beyond treating the block itself as a typed node whose type identity is `SrcComponent`, not `Type Reference` generically — two `Reference` blocks with different `SrcComponent` values are different component types for topology purposes even though both say `Type Reference`.
+
+## 5. Behavior when the target is missing or changed
+
+> "If PLECS is unable to resolve a library reference, it highlights the reference component and issues an error message."
+> — https://docs.plexim.com/plecs/5.0/using-plecs/libraries/
+
+This is a hard **error**, not a silent substitution and not merely a warning — for the case of the *library itself* being unreachable (unresolvable path). Recovery per the docs is either recreating the reference or restoring the library to the search path and reloading.
+
+The documentation available through the plecs-expert skill's offline reference and the fetched pages does **not** address the narrower case of the library file being found but the specific *component within it* having been renamed or deleted (as opposed to the whole library being missing) — that finding could not be sourced and is left open rather than guessed.
+
+## 6. Corpus evidence: what do the 82 targets actually resolve to?
+
+Every `SrcComponent` value immediately following a `Type Reference` line, across all 25 local sample files (82 blocks total), was extracted directly (not from memory) and inspected. All 82 resolve to a path of the shape:
+
+```
+Components/<Category>/<Subcategory>/<Component Name>
+```
+
+Observed distinct targets (17 unique library components, reused across models):
+
+```
+Components/Assertions/Assert Range
+Components/Control/Continuous/Continuous PID\nController
+Components/Control/Continuous/Three-Phase PLL
+Components/Control/Delays/Pulse Delay
+Components/Control/Delays/Turn-on Delay
+Components/Control/Filters/Moving Average
+Components/Control/Filters/Periodic Average
+Components/Control/Filters/RMS Value
+Components/Control/Logical/D Flip-flop
+Components/Control/Logical/SR Flip-flop
+Components/Control/Modulators/6-Pulse\nGenerator
+Components/Control/Modulators/Blanking Time
+Components/Control/Modulators/Peak Current\nController
+Components/Control/Modulators/Symmetrical PWM
+Components/Electrical/Converters/Diode\nRectifier
+Components/Electrical/Transformers/Ydy Trafo
+```
+
+Distribution by file (block count, verified with `grep -A1 -E "^\s*Type\s+Reference\s*$"` per file against the maintainer's local `data/` directory — 5 files, 4 of the 5 tracked-in-git files, have zero `Reference` blocks and are omitted):
+
+| File | Reference blocks | Targets |
+|---|---|---|
+| `05_DAB_TCM_OTM_CPM_Script_data.plecs` | 12 | Turn-on Delay ×2, Periodic Average, Moving Average, Blanking Time ×8 |
+| `12-pulse-rectifier-bl.plecs` | 4 | 6-Pulse Generator ×2, Three-Phase PLL, Ydy Trafo |
+| `4th_leg_dcm_const_ripple.plecs` | 5 | Symmetrical PWM ×2, Continuous PID Controller, Moving Average ×2 |
+| `B6_diode.plecs` | 1 | Diode Rectifier |
+| `bdc_nibb.plecs` | 9 | SR Flip-flop ×2, Assert Range ×2, Turn-on Delay ×2, Moving Average, D Flip-flop ×2 |
+| `bst_bcm_bsc5.plecs` | 3 | Turn-on Delay ×2, SR Flip-flop |
+| `bst_bcm_bsc5_cscript.plecs` | 3 | Turn-on Delay ×2, SR Flip-flop |
+| `buck_converter_bcm_rt.plecs` | 13 | Assert Range, Pulse Delay ×8, Turn-on Delay ×3, SR Flip-flop |
+| `nibb_EKK_1.plecs` | 4 | Turn-on Delay ×2, SR Flip-flop ×2 |
+| `nibb_EKK_2.plecs` | 5 | Turn-on Delay ×2, SR Flip-flop ×2, Peak Current Controller |
+| `nibb_EKK_3.plecs` | 5 | Turn-on Delay ×2, SR Flip-flop ×2, Peak Current Controller |
+| `simple_nibb_prb.plecs` (**tracked**) | 2 | RMS Value ×2 |
+| `simple_nibb_prb_or.plecs` | 2 | RMS Value ×2 |
+| `simple_nibb_prb_show.plecs` | 6 | RMS Value ×3, SR Flip-flop, Continuous PID Controller, Peak Current Controller |
+| `simple_nibb_prb_vctrl.plecs` | 6 | (same set as `_show`) |
+| `test_short.plecs` | 2 | RMS Value ×2 |
+| **Total** | **82** | |
+
+**None of the 82 targets lie outside the repository as another project's model file, another user's `.plecs`, or an absolute filesystem path.** All 82 point into the PLECS standard Component Library, which is bundled with every PLECS installation. So in the narrow sense of "does a target point at a sibling `.plecs` file somewhere on disk that isn't in this repo" — no, none do.
+
+But the target *does* lie outside the repository in the sense that matters for the cache key: **the PLECS Component Library is not part of this git repository, is not pinned by these `.plecs` files, and its content can change between PLECS versions/installations independent of any change to the `.plecs` file's bytes** (see §3). No `Reference` block in the corpus points to a fully self-contained, in-file definition — every one of them is an external dependency by construction, just one that's externalized to "the PLECS install" rather than "another file in `data/`."
+
+## Summary for the map decision
+
+| Question | Answer |
+|---|---|
+| Is `Reference` a library link, alias, or external subsystem instance? | Library link (to the built-in PLECS Component Library in every corpus block observed) |
+| Copied into `.plecs` on save, or resolved at load/run time? | **Resolved at load time**, re-propagated at simulation start; not embedded |
+| Can it be masked/parameterised? | Parameters yes (per-instance `Variable`/`Value` overrides, same symbol/literal shape as decision 4); mask itself is inherited, not per-instance re-authorable |
+| Missing/changed target behavior | Error + highlighted block when the *library* is unresolvable; renamed/deleted *component within* an otherwise-resolvable library is undocumented in available sources |
+| Do any of the 82 corpus targets point outside the repo? | Not to another file on disk, but yes to the installed PLECS Component Library — an external, version-dependent dependency not captured by file bytes |
+
+The correctness stake: a topology cache key that hashes `.plecs` bytes (or a canonicalized form of them) alone, without recording anything about the resolved `Reference` targets or the PLECS version resolving them, can produce a wrong cache hit across a PLECS upgrade that changes a linked library component's internal behavior — the exact failure the governing invariant forbids. Whether the fix is a `solver_id`/environment component recording PLECS version, a dedicated coverage flag for `Reference` blocks, or something else is left to the design spec this ticket feeds.
+
+## Sources
+
+- https://docs.plexim.com/plecs/5.0/using-plecs/libraries/ (fetched via WebFetch; page not present in the plecs-expert skill's offline `references/` cache)
+- `D:\OneDrive\claude\pyplecs\.claude\skills\plecs-expert\references\components\system.md` (offline plecs-expert reference; masking-subsystems tables, sourced from https://docs.plexim.com/plecs/latest/using-plecs/masking-subsystems/)
+- Direct inspection of `data/*.plecs` — both the 5 files tracked on `master` and the maintainer's local (gitignored, untracked) 25-file sample set at `D:\OneDrive\claude\pyplecs\data\`, using `grep -A1 -E "^\s*Type\s+Reference\s*$"` and `Read` on specific line ranges.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,10 @@ nav:
     - ADR-0006 Two model flavors: adr/0006-two-model-flavors-no-merge.md
     - ADR-0007 Verbatim tables: adr/0007-verbatim-tables-rewritten-prose.md
     - ADR-0008 uv owns dependencies: adr/0008-pyproject-and-uv-own-dependencies.md
-  - Research: research/README.md
+  - Research:
+    - Index: research/README.md
+    - Offline symbol resolution: research/2026-08-19-offline-symbol-resolution.md
+    - PLECS Reference semantics: research/2026-08-19-plecs-reference-semantics.md
   - Agents:
     - Domain docs: agents/domain.md
     - Issue tracker: agents/issue-tracker.md


### PR DESCRIPTION
Prerequisite for branch cleanup. `research/offline-symbol-resolution` and `research/plecs-reference-semantics` each carry one findings file and were **never merged** — no PR was ever opened for either.

Worse, both sat at `docs/superpowers/research/`, which [ADR-0004](docs/adr/0004-code-is-the-only-architecture-truth.md) gitignored — so they would have been unreachable even if the branches *had* merged.

They are precisely what `docs/research/` exists for: findings with sources, no decisions, no status, dated and not revised.

**Closed issues #33 and #34 point at them, and open wayfinder map #30 cites both** — so deleting those branches without moving the files first would have broken live references from an open map.

Content is verbatim from the branch tips; only the location changed. One finding records a discrepancy worth keeping visible: the ticket assumed 25 models in `data/*.plecs`, and there are 5.

Verified: `mkdocs build --strict` clean with both files in the nav.

Refs: #33, #34, #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)