### PR TITLE
feat(converter): keep the LTspice drawing in the emitted .plecs (#94)

### DIFF
--- a/pyplecs/converter/circuit.py
+++ b/pyplecs/converter/circuit.py
@@ -2,6 +2,9 @@
 
 from dataclasses import dataclass, field
 
+Point = tuple[int, int]
+"""One schematic coordinate, Circuit Model convention: y grows downward, unit is PLECS px."""
+
 
 @dataclass(frozen=True)
 class Pin:
@@ -19,7 +22,11 @@ class Pin:
 
 @dataclass
 class Component:
-    """One tool-neutral circuit component parsed from a foreign format."""
+    """One tool-neutral circuit component parsed from a foreign format.
+
+    ``position`` is the component's body centre in Circuit Model schematic coordinates
+    (the PLECS convention: y grows downward, unit is PLECS px).
+    """
 
     name: str
     type: str
@@ -31,10 +38,18 @@ class Component:
 
 @dataclass
 class Net:
-    """One electrical connection shared by component pins."""
+    """One electrical connection shared by component pins.
+
+    ``segments`` and ``pin_points`` are optional wire-drawing geometry in Circuit Model
+    schematic coordinates (see ``Component.position``): ``segments`` are the wire pieces
+    of this net, ``pin_points`` is where each pin attaches to them. Both default empty for
+    formats without layout; every parser/emitter that ignores them keeps working.
+    """
 
     name: str
     pins: list[Pin] = field(default_factory=list)
+    segments: list[tuple[Point, Point]] = field(default_factory=list)
+    pin_points: dict[Pin, Point] = field(default_factory=dict)
 
 
 @dataclass
@@ -62,4 +77,9 @@ class Circuit:
             if unknown:
                 raise ValueError(
                     f"Circuit net '{net.name}' references unknown component(s): {', '.join(sorted(set(unknown)))}"
+                )
+            stray_pin_points = [pin for pin in net.pin_points if pin not in net.pins]
+            if stray_pin_points:
+                raise ValueError(
+                    f"Circuit net '{net.name}' has pin_points for pin(s) not in its pins: {stray_pin_points}"
                 )

--- a/pyplecs/converter/emitters/plecs.py
+++ b/pyplecs/converter/emitters/plecs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Sequence
 
-from ..circuit import Circuit, Component, Net
+from ..circuit import Circuit, Component, Net, Pin, Point
 
 
 @dataclass(frozen=True)
@@ -195,6 +195,8 @@ def _connection_block(net: Net, component_types: Mapping[str, str]) -> list[str]
         or (component_types.get(pin.component) == "Mosfet" and pin.terminal == 3)
         for pin in pins
     )
+    if net.segments and all(pin in net.pin_points for pin in pins):
+        return _routed_connection_block(net, pins, signal)
     source = pins[0]
     lines = [
         "    Connection {",
@@ -221,6 +223,167 @@ def _connection_block(net: Net, component_types: Mapping[str, str]) -> list[str]
             )
     lines.append("    }")
     return lines
+
+
+def _routed_connection_block(net: Net, pins: list[Pin], signal: bool) -> list[str]:
+    """Route ``net``'s Connection block along its drawn wires instead of a flat pin list (#94)."""
+    source = pins[0]
+    attach: dict[Point, list[Pin]] = {}
+    for pin in pins:
+        attach.setdefault(net.pin_points[pin], []).append(pin)
+
+    protected = set(net.pin_points.values())
+    adjacency = _segment_graph(net.segments, protected)
+    _prune_dangling_stubs(adjacency, protected)
+
+    source_point = net.pin_points[source]
+    tree_children: dict[Point, list[Point]] = {}
+    reachable: set[Point] = set()
+    if source_point in adjacency:
+        _build_spanning_tree(adjacency, source_point, None, reachable, tree_children)
+
+    lines = [
+        "    Connection {",
+        f"      Type          {'Signal' if signal else 'Wire'}",
+        f'      SrcComponent  "{_quoted(source.component)}"',
+        f"      SrcTerminal   {source.terminal}",
+    ]
+    lines.extend(_walk_net(source_point, None, [source_point], tree_children, attach, source, 6))
+    for pin in pins[1:]:
+        if net.pin_points[pin] not in reachable:
+            lines.extend(_branch_dst(pin, 6))
+    lines.append("    }")
+    return lines
+
+
+def _segment_graph(segments: list[tuple[Point, Point]], extra_nodes: set) -> dict[Point, set]:
+    """Build the wire graph: nodes are segment endpoints plus pin attach points lying on them."""
+    all_points = set(extra_nodes)
+    for start, end in segments:
+        all_points.add(start)
+        all_points.add(end)
+    adjacency: dict[Point, set] = {}
+    for start, end in segments:
+        on_segment = [point for point in all_points if _on_segment(point, start, end)]
+        on_segment.sort(key=lambda p: (p[0] - start[0]) * (end[0] - start[0]) + (p[1] - start[1]) * (end[1] - start[1]))
+        for a, b in zip(on_segment, on_segment[1:]):
+            adjacency.setdefault(a, set()).add(b)
+            adjacency.setdefault(b, set()).add(a)
+    return adjacency
+
+
+def _on_segment(point: Point, start: Point, end: Point) -> bool:
+    (px, py), (x1, y1), (x2, y2) = point, start, end
+    if (x2 - x1) * (py - y1) != (y2 - y1) * (px - x1):
+        return False
+    return min(x1, x2) <= px <= max(x1, x2) and min(y1, y2) <= py <= max(y1, y2)
+
+
+def _prune_dangling_stubs(adjacency: dict[Point, set], protected: set) -> None:
+    """Repeatedly drop degree-<=1 nodes that carry no pin (a dangling body/ground-flag stub)."""
+    changed = True
+    while changed:
+        changed = False
+        for node in list(adjacency):
+            neighbors = adjacency.get(node)
+            if neighbors is not None and len(neighbors) <= 1 and node not in protected:
+                for neighbor in neighbors:
+                    adjacency[neighbor].discard(node)
+                del adjacency[node]
+                changed = True
+
+
+def _build_spanning_tree(
+    adjacency: dict[Point, set],
+    node: Point,
+    parent: Point | None,
+    visited: set,
+    tree_children: dict[Point, list[Point]],
+) -> None:
+    visited.add(node)
+    children = [
+        neighbor for neighbor in sorted(adjacency.get(node, ())) if neighbor != parent and neighbor not in visited
+    ]
+    for child in children:
+        visited.add(child)
+    tree_children[node] = children
+    for child in children:
+        _build_spanning_tree(adjacency, child, node, visited, tree_children)
+
+
+def _walk_net(
+    node: Point,
+    prev: Point | None,
+    run: list[Point],
+    tree_children: dict[Point, list[Point]],
+    attach: Mapping[Point, list[Pin]],
+    exclude_pin: Pin | None,
+    indent: int,
+) -> list[str]:
+    """Emit Points/Dst/Branch lines walking the spanning tree from ``node`` onward (plan step 4)."""
+    while True:
+        pins_here = [pin for pin in attach.get(node, ()) if pin != exclude_pin]
+        children = tree_children.get(node, [])
+
+        if not pins_here and not children:
+            return []
+
+        if not pins_here and len(children) == 1:
+            child = children[0]
+            if prev is not None and _run_direction(prev, node) != _run_direction(node, child):
+                run.append(node)
+            prev, node = node, child
+            continue
+
+        if len(pins_here) == 1 and not children:
+            run.append(node)
+            return _points_line(run, indent) + _dst_lines(pins_here[0], indent)
+
+        run.append(node)
+        lines = _points_line(run, indent)
+        for pin in pins_here:
+            lines.extend(_branch_dst(pin, indent))
+        for child in children:
+            lines.extend(_branch_child(child, node, tree_children, attach, indent))
+        return lines
+
+
+def _branch_child(
+    child: Point,
+    parent: Point,
+    tree_children: dict[Point, list[Point]],
+    attach: Mapping[Point, list[Pin]],
+    indent: int,
+) -> list[str]:
+    inner_indent = indent + 2
+    body = _walk_net(child, parent, [], tree_children, attach, None, inner_indent)
+    return [f"{' ' * indent}Branch {{", *body, f"{' ' * indent}}}"]
+
+
+def _branch_dst(pin: Pin, indent: int) -> list[str]:
+    inner_indent = indent + 2
+    return [f"{' ' * indent}Branch {{", *_dst_lines(pin, inner_indent), f"{' ' * indent}}}"]
+
+
+def _dst_lines(pin: Pin, indent: int) -> list[str]:
+    return [
+        f'{" " * indent}DstComponent  "{_quoted(pin.component)}"',
+        f"{' ' * indent}DstTerminal   {pin.terminal}",
+    ]
+
+
+def _points_line(run: list[Point], indent: int) -> list[str]:
+    if not run:
+        return []
+    points = "; ".join(f"{x}, {y}" for x, y in run)
+    return [f"{' ' * indent}Points        [{points}]"]
+
+
+def _run_direction(a: Point, b: Point) -> tuple[int, int]:
+    def sign(v: int) -> int:
+        return (v > 0) - (v < 0)
+
+    return (sign(b[0] - a[0]), sign(b[1] - a[1]))
 
 
 def _validate_graph(components: Iterable[Component], nets: Iterable[Net]) -> None:

--- a/pyplecs/converter/ltspice_parser.py
+++ b/pyplecs/converter/ltspice_parser.py
@@ -28,9 +28,6 @@ SYMBOL_PINS: dict[str, tuple[tuple[int, int], ...]] = {
 # LTspice symbol → PLECS component type, the inverse of the SPICE mapper table.
 SYMBOL_TYPES = {mapping.symbol: plecs_type for plecs_type, mapping in COMPONENT_MAPPINGS.items() if mapping.symbol in SYMBOL_PINS}
 
-# LTspice orientation → cosmetic PLECS direction (connections are by terminal, so this is layout only).
-_DIRECTIONS = {0: "down", 90: "left", 180: "up", 270: "right"}
-
 _SUFFIXES = {"t": "e12", "g": "e9", "meg": "e6", "k": "e3", "m": "e-3", "u": "e-6", "µ": "e-6", "n": "e-9", "p": "e-12", "f": "e-15"}
 _SUFFIXED_NUMBER = re.compile(r"(?<![\w.])(\d+\.?\d*|\.\d+)(meg|[tgkmunpfµ])(?![\w])", re.IGNORECASE)
 
@@ -87,24 +84,44 @@ def parse_ltspice_text(text: str, *, name: str = "circuit") -> Circuit:
             initial = re.search(r"\bic=(\S+)", attrs.get("SpiceLine", ""))
             if initial:
                 parameters[mapping.initial_parameter] = to_plecs_expression(initial.group(1))
-        rotation = int(symbol["orient"][1:] or 0) % 360
+        absolute_pins = [
+            (symbol["x"] + dx, symbol["y"] + dy)
+            for dx, dy in (transform_offset(symbol["orient"], *offset) for offset in SYMBOL_PINS[symbol["symbol"]])
+        ]
+        p1, p2 = absolute_pins
         components.append(
             Component(
                 name=component_name,
                 type=plecs_type,
-                position=(symbol["x"] // 2, symbol["y"] // 2),
-                direction=_DIRECTIONS[rotation],
-                flipped=symbol["orient"].startswith("M"),
+                position=_scale(((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)),
+                direction=_direction(p1, p2),
+                flipped=False,
                 parameters=parameters,
             )
         )
-        for terminal, offset in enumerate(SYMBOL_PINS[symbol["symbol"]], start=1):
-            dx, dy = transform_offset(symbol["orient"], *offset)
-            pin_points.append((Pin(component_name, terminal), (symbol["x"] + dx, symbol["y"] + dy)))
+        for terminal, point in enumerate(absolute_pins, start=1):
+            pin_points.append((Pin(component_name, terminal), point))
 
     nets = _build_nets(wires, flags, pin_points)
     raw_params = _parameters(directives)
     return Circuit(name=name, components=components, nets=nets, raw_params=raw_params)
+
+
+def _scale(point: tuple[float, float]) -> tuple[int, int]:
+    """LTspice (grid 16) → Circuit Model/PLECS (grid 10) schematic coordinates."""
+    x, y = point
+    return (round(x * 5 / 8), round(y * 5 / 8))
+
+
+def _direction(p1: tuple[int, int], p2: tuple[int, int]) -> str:
+    """PLECS Direction names the side terminal 1 (``p1``) faces, derived from the two pin points."""
+    if p1[1] < p2[1]:
+        return "up"
+    if p1[1] > p2[1]:
+        return "down"
+    if p1[0] < p2[0]:
+        return "left"
+    return "right"
 
 
 def transform_offset(orient: str, x: int, y: int) -> tuple[int, int]:
@@ -198,6 +215,11 @@ def _build_nets(
             nets[root] = Net(name=name)
             order.append(root)
         nets[root].pins.append(pin)
+        nets[root].pin_points[pin] = _scale(point)
+    for start, end in wires:  # a wire whose root owns no pin belongs to no net; drop it
+        root = find(start)
+        if root in nets:
+            nets[root].segments.append((_scale(start), _scale(end)))
     return [nets[root] for root in order]
 
 

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/comparison.json
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/comparison.json
@@ -1,0 +1,42 @@
+{
+  "analytic_passed": true,
+  "at_time": 5e-06,
+  "checkpoints": {
+    "3tau": {
+      "analytic": 0.950212931632136,
+      "candidate": 0.9502129316321274,
+      "candidate_error": 8.659739592076221e-15,
+      "reference": 0.9502129387424342,
+      "reference_error": 7.110298128054637e-09,
+      "t": 0.003
+    },
+    "end": {
+      "analytic": 0.9932620530009145,
+      "candidate": 0.9932620530009142,
+      "candidate_error": 3.3306690738754696e-16,
+      "reference": 0.9932620558074453,
+      "reference_error": 2.806530785548489e-09,
+      "t": 0.005
+    },
+    "tau": {
+      "analytic": 0.6321205588285577,
+      "candidate": 0.6321205588284782,
+      "candidate_error": 7.949196856316121e-14,
+      "reference": 0.6321205500548944,
+      "reference_error": 8.77366324036899e-09,
+      "t": 0.001
+    }
+  },
+  "grid": {
+    "points": 2001,
+    "span": 0.005
+  },
+  "max_relative_difference": 1.062332822959755e-07,
+  "max_relative_error_vs_analytic": {
+    "candidate": 1.2468792700420783e-07,
+    "reference": 1.0623332983000083e-07
+  },
+  "passed": true,
+  "signal": "v_C",
+  "tolerance": 0.01
+}

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/conversion.md
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/conversion.md
@@ -1,0 +1,5 @@
+```
+uv run pyplecs-convert tests/fixtures/rc_step.asc --format plecs --probe 'C1:Capacitor voltage' --probe 'R1:Resistor current' -o tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import
+```
+Circuit Model: 3 components, 3 nets; parameters {'V_step': '1', 'R': '1e3', 'C': '1e-6', 'T_sim': '5e-3', 'max_step': '1e-6'}.
+The step is applied at t = 0: DC source with the capacitor's initial voltage 0 in both simulators (`ic=0` + `uic` in LTspice).

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/environment.json
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/environment.json
@@ -1,0 +1,12 @@
+{
+  "ltspice": "LTspice 26.0.1 for Windows",
+  "platform": "Windows-11-10.0.26200-SP0",
+  "plecs": "live PLECS 4.7.7 at localhost:1080",
+  "pyplecs": "1.0.0",
+  "python": "3.14.0",
+  "recorded_at": "2026-08-29T21:09:32.870184+00:00",
+  "samples": {
+    "ltspice": 5018,
+    "plecs": 5001
+  }
+}

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/rc_step.asc
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/rc_step.asc
@@ -1,0 +1,25 @@
+Version 4
+SHEET 1 880 680
+WIRE 96 96 96 80
+WIRE 240 96 96 96
+WIRE 336 96 320 96
+WIRE 96 208 96 176
+WIRE 336 208 336 160
+WIRE 336 208 96 208
+WIRE 96 224 96 208
+FLAG 96 224 0
+SYMBOL voltage 96 80 R0
+SYMATTR InstName V1
+SYMATTR Value {V_step}
+SYMBOL res 336 80 R90
+SYMATTR InstName R1
+SYMATTR Value {R}
+SYMBOL cap 320 96 R0
+SYMATTR InstName C1
+SYMATTR Value {C}
+SYMATTR SpiceLine ic=0
+TEXT 0 300 Left 2 !.param V_step=1
+TEXT 0 324 Left 2 !.param R=1k
+TEXT 0 348 Left 2 !.param C=1u
+TEXT 0 372 Left 2 !.param T_sim=5m
+TEXT 0 396 Left 2 !.tran 0 {T_sim} 0 1u uic

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/rc_step.plecs
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/rc_step.plecs
@@ -1,0 +1,147 @@
+Plecs {
+  Name          "rc_step"
+  Version       "4.7"
+  CircuitModel  "ContStateSpace"
+  StartTime     "0.0"
+  TimeSpan      "T_sim"
+  Timeout       ""
+  Solver        "radau"
+  MaxStep       "max_step"
+  InitStep      "-1"
+  FixedStep     "1e-3"
+  Refine        "1"
+  ZCStepSize    "1e-9"
+  RelTol        "1e-3"
+  AbsTol        "-1"
+  TurnOnThreshold "1"
+  InitializationCommands "C = 1e-6;\nR = 1e3;\nT_sim = 5e-3;\nV_step = 1;\nmax_step = 1e-6;\n"
+  InitialState  "1"
+  SystemState   ""
+  Terminal {
+    Type          Output
+    Index         "1"
+  }
+  Schematic {
+    Location      [0, 0; 900, 600]
+    ZoomFactor    1
+    SliderPosition [0, 0]
+    ShowBrowser   off
+    BrowserWidth  100
+    Component {
+      Type          Capacitor
+      Name          "C1"
+      Show          on
+      Position      [210, 80]
+      Direction     up
+      Flipped       off
+      LabelPosition south
+      Parameter {
+        Variable      "C"
+        Value         "C"
+        Show          off
+      }
+      Parameter {
+        Variable      "v_init"
+        Value         "0"
+        Show          off
+      }
+    }
+    Component {
+      Type          Resistor
+      Name          "R1"
+      Show          on
+      Position      [175, 60]
+      Direction     right
+      Flipped       off
+      LabelPosition south
+      Parameter {
+        Variable      "R"
+        Value         "R"
+        Show          off
+      }
+    }
+    Component {
+      Type          DCVoltageSource
+      Name          "V1"
+      Show          on
+      Position      [60, 85]
+      Direction     up
+      Flipped       off
+      LabelPosition south
+      Parameter {
+        Variable      "V"
+        Value         "V_step"
+        Show          off
+      }
+    }
+    Component {
+      Type          PlecsProbe
+      Name          "__tas_probe"
+      Show          off
+      Position      [720, 120]
+      Direction     right
+      Flipped       off
+      LabelPosition south
+      Probe {
+        Component     "C1"
+        Path          ""
+        Signals       {"Capacitor voltage"}
+      }
+      Probe {
+        Component     "R1"
+        Path          ""
+        Signals       {"Resistor current"}
+      }
+    }
+    Component {
+      Type          Output
+      Name          "__tas_output"
+      Show          on
+      Position      [820, 120]
+      Direction     right
+      Flipped       off
+      LabelPosition south
+      Parameter {
+        Variable      "Index"
+        Value         "1"
+        Show          on
+      }
+      Parameter {
+        Variable      "Width"
+        Value         "-1"
+        Show          off
+      }
+    }
+    Connection {
+      Type          Wire
+      SrcComponent  "C1"
+      SrcTerminal   2
+      Points        [210, 100; 210, 130; 60, 130; 60, 110]
+      DstComponent  "V1"
+      DstTerminal   2
+    }
+    Connection {
+      Type          Wire
+      SrcComponent  "R1"
+      SrcTerminal   2
+      Points        [150, 60; 60, 60]
+      DstComponent  "V1"
+      DstTerminal   1
+    }
+    Connection {
+      Type          Wire
+      SrcComponent  "C1"
+      SrcTerminal   1
+      Points        [210, 60; 200, 60]
+      DstComponent  "R1"
+      DstTerminal   1
+    }
+    Connection {
+      Type          Signal
+      SrcComponent  "__tas_probe"
+      SrcTerminal   1
+      DstComponent  "__tas_output"
+      DstTerminal   1
+    }
+  }
+}

--- a/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/summary.md
+++ b/tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/summary.md
@@ -1,0 +1,11 @@
+# rc_step — LTspice schematic imported to PLECS, step response compared
+
+LTspice 26.0.1 for Windows (reference, 5018 samples) vs PLECS 4.7.7 (5001 samples) on `v_C`, 0 … 0.005 s, τ = 0.001 s.
+
+**Verdict: PASS** — max |Δ| / step = 1.062e-07 (tolerance 1.0%) at t = 5e-06 s; vs analytic: LTspice 1.062e-07, PLECS 1.247e-07.
+
+| point | t [s] | analytic | LTspice | PLECS | LTspice err | PLECS err |
+|---|---|---|---|---|---|---|
+| tau | 0.001 | 0.63212 | 0.63212 | 0.63212 | 0.000% | 0.000% |
+| 3tau | 0.003 | 0.95021 | 0.95021 | 0.95021 | 0.000% | 0.000% |
+| end | 0.005 | 0.99326 | 0.99326 | 0.99326 | 0.000% | 0.000% |

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -17,6 +17,7 @@ from pyplecs.converter import (
     plecs_to_spice,
 )
 from pyplecs.converter.cli import main as converter_main
+from pyplecs.converter.emitters import emit_plecs
 from pyplecs.converter.mapper import map_component, spice_expression
 from pyplecs.converter.parser import PlecsParseError, parse_plecs_text
 
@@ -244,6 +245,43 @@ def test_parse_plecs_text_keeps_brace_list_values_across_continuation_lines():
     axis = document["Plecs"]["Schematic"]["Component"]["Axis"]
     assert axis["Signals"] == '{"Load Current", "Inductor Current", "Average Inductor Current"}'
     assert axis["SignalTypes"] == ()
+
+
+def test_routed_connection_regression_lock_for_plecs_native_circuits():
+    """parse_plecs never populates segments/pin_points (#94); emit_plecs must stay byte-identical for such circuits."""
+    circuit = parse_plecs(DATA_DIR / "simple_buck_prb.plecs")
+    assert all(not net.segments and not net.pin_points for net in circuit.nets)
+
+    text = emit_plecs(circuit)
+
+    assert "Points" not in text
+    ground = next(net for net in circuit.nets if net.name == "0")
+    assert len(ground.pins) == 4
+    block = next(
+        m.group(0)
+        for m in re.finditer(r'    Connection \{\n(?:.*\n)*?    \}\n', text)
+        if 'SrcComponent  "C1"' in m.group(0) and 'SrcTerminal   2' in m.group(0)
+    )
+    expected = (
+        '    Connection {\n'
+        '      Type          Wire\n'
+        '      SrcComponent  "C1"\n'
+        '      SrcTerminal   2\n'
+        '      Branch {\n'
+        '        DstComponent  "D1"\n'
+        '        DstTerminal   1\n'
+        '      }\n'
+        '      Branch {\n'
+        '        DstComponent  "R1"\n'
+        '        DstTerminal   2\n'
+        '      }\n'
+        '      Branch {\n'
+        '        DstComponent  "VDCin"\n'
+        '        DstTerminal   2\n'
+        '      }\n'
+        '    }\n'
+    )
+    assert block == expected
 
 
 def test_plecs_power_operator_becomes_spice_power_in_every_emitted_expression():

--- a/tests/test_ltspice_import.py
+++ b/tests/test_ltspice_import.py
@@ -1,5 +1,6 @@
 """LTspice ``.asc`` import into the Circuit Model, and out again as a runnable ``.plecs`` (#43 track 1)."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,101 @@ from pyplecs.converter.ltspice_parser import (
 
 FIXTURES = Path(__file__).parent / "fixtures"
 RC_STEP = FIXTURES / "rc_step.asc"
+
+
+def _connection_block(text: str, src_component: str) -> str:
+    match = re.search(
+        rf'    Connection \{{\n(?:.*\n)*?      SrcComponent  "{re.escape(src_component)}"\n(?:.*\n)*?    \}}\n',
+        text,
+    )
+    assert match, f"no Connection block found with SrcComponent {src_component!r}"
+    return match.group(0)
+
+
+def test_rc_step_component_geometry_matches_the_authored_drawing():
+    """Position/Direction are derived from the two absolute pin points (#94); verified by hand against the fixture."""
+    circuit = parse_ltspice(RC_STEP)
+    by_name = {c.name: c for c in circuit.components}
+    assert by_name["V1"].position == (60, 85) and by_name["V1"].direction == "up"
+    assert by_name["R1"].position == (175, 60) and by_name["R1"].direction == "right"
+    assert by_name["C1"].position == (210, 80) and by_name["C1"].direction == "up"
+    assert all(not c.flipped for c in circuit.components)
+
+
+def test_rc_step_routing_follows_the_authored_wires():
+    """Connection Points/Branch geometry follows the drawn wires (#94), pruning dangling body/ground stubs."""
+    text = ltspice_to_plecs(RC_STEP)
+
+    n001 = _connection_block(text, "R1")
+    assert 'SrcTerminal   2' in n001
+    assert "Points        [150, 60; 60, 60]" in n001
+    assert 'DstComponent  "V1"' in n001 and "DstTerminal   1" in n001
+    assert "80" not in re.search(r"Points\s+\[[^\]]*\]", n001).group(0)
+
+    n002 = _connection_block(text, "C1")
+    # C1 sources both non-ground nets; pick the one destined for R1 terminal 1
+    n002_block = next(
+        block
+        for block in re.findall(r'    Connection \{\n(?:.*\n)*?    \}\n', text)
+        if 'SrcComponent  "C1"' in block and 'DstComponent  "R1"' in block
+    )
+    assert 'SrcTerminal   1' in n002_block
+    assert "Points        [210, 60; 200, 60]" in n002_block
+    assert "DstTerminal   1" in n002_block
+
+    ground_block = next(
+        block
+        for block in re.findall(r'    Connection \{\n(?:.*\n)*?    \}\n', text)
+        if 'SrcComponent  "C1"' in block and 'DstComponent  "V1"' in block
+    )
+    assert 'SrcTerminal   2' in ground_block
+    assert "Points        [210, 100; 210, 130; 60, 130; 60, 110]" in ground_block
+    assert "DstTerminal   2" in ground_block
+    assert "140" not in text  # the FLAG 96 224 0 stub (scaled y=140) is pruned
+
+
+@pytest.mark.parametrize(
+    "orient, expected_direction",
+    [
+        ("R0", "up"),
+        ("R90", "right"),
+        ("R180", "down"),
+        ("R270", "left"),
+        ("M0", "up"),
+        ("M90", "left"),
+        ("M180", "down"),
+        ("M270", "right"),
+    ],
+)
+def test_symbol_direction_reflects_which_side_terminal_one_faces(orient, expected_direction):
+    """Direction names the side terminal 1 faces (#94); Flipped is never emitted for a two-terminal part."""
+    text = (
+        f"Version 4\nSHEET 1 400 400\nSYMBOL res 100 100 {orient}\nSYMATTR InstName R1\nSYMATTR Value 1\n"
+        "TEXT 0 0 Left 2 !.tran 1m\n"
+    )
+    circuit = parse_ltspice_text(text)
+    component = circuit.components[0]
+    assert component.direction == expected_direction
+    assert component.flipped is False
+
+
+def test_pass_through_pins_emit_branches_at_the_interior_points():
+    """Four pins share one wire; the two interior ones must appear as Dst branches, not swallowed (#94)."""
+    text = (
+        "Version 4\nSHEET 1 400 400\n"
+        "WIRE 0 100 300 100\n"
+        "SYMBOL res 100 84 R90\nSYMATTR InstName R1\nSYMATTR Value 1\n"
+        "SYMBOL res 300 84 R90\nSYMATTR InstName R2\nSYMATTR Value 1\n"
+        "FLAG 150 100 mid\n"
+        "TEXT 0 0 Left 2 !.tran 1m\n"
+    )
+    circuit = parse_ltspice_text(text)
+    text_out = ltspice_to_plecs(circuit)
+    block = _connection_block(text_out, min(p.component for p in circuit.nets[0].pins))
+    # every pin ends up either as the Src, a leaf Dst, or a Branch Dst
+    for pin in circuit.nets[0].pins:
+        assert f'"{pin.component}"' in block
+    assert block.count("Branch {") >= 2
 
 
 def test_rc_step_schematic_becomes_the_circuit_model_ltspice_netlists():


### PR DESCRIPTION
Closes #94. Follow-up recorded as #95 (auto-layout for sources without geometry).

## Why

The `.plecs` emitted from an `.asc` simulated correctly but the schematic was misleading: bodies displaced from their wires, wires through bodies, every multi-pin net a star. Three causes, all fixed here:

1. `Position` was the LTspice symbol origin; PLECS `Position` is the body centre.
2. `Direction` was 180° off. Mining PLECS 4.7 `demos/*.plecs` + `components.plecs` (hundreds of connections): `Direction` names the side **terminal 1** faces, `Flipped on` swaps the ends. `R0` (pin 1 on top) is `up`, not `down`; `M*` becomes the opposite direction, never `Flipped on`.
3. `WIRE` geometry was discarded; the emitter wrote point-less `Connection`s branching off `pins[0]`.

## What changed

- `Net` gains optional `segments` / `pin_points` (Circuit Model coordinates = PLECS convention). Empty for every other parser; those paths emit byte-for-byte what they did (regression-locked on `simple_buck_prb.plecs`).
- LTspice parser: 16 → 10 grid scale, centre between pins, direction from pin 1, `flipped=False`.
- PLECS emitter: segment graph → `Connection`/`Branch` tree; dangling stubs pruned; only corners + attach points as `Points`; `Branch` at junctions and pass-through pins; unreachable pins fall back to the old point-less branch.

## Evidence

- Default gate: `ruff` clean; full suite 269 passed with PLECS up.
- Live: `-m converter_acceptance -k rc_step` on LTspice 26.0.1 vs PLECS 4.7.7 — PASS, max |Δ|/step = 1.06e-7. Bundle `tests/evidence/rc_step/step/2026-08-29T210930Z-ltspice-import/` (compare the `Points`/`Position` lines with the 12:29Z bundle for before/after).

## Not touched

`emitters/ltspice.py::_orientation` is wrong under the same semantics (`up → R270`) — that is the `.asc` emitter defect on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
